### PR TITLE
Lra 37 create an archive method to replace the delete destroy functionality

### DIFF
--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register AdminUser do
+  menu parent: 'Logins Info', priority: 1
   permit_params :email, :password, :password_confirmation
 
   index do

--- a/app/admin/data_classification_levels.rb
+++ b/app/admin/data_classification_levels.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register DataClassificationLevel do
+  menu parent: 'Complementary Tables', priority: 1
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/admin/data_types.rb
+++ b/app/admin/data_types.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register DataType do
+  menu parent: 'Complementary Tables', priority: 1
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/admin/dpa_exceptions.rb
+++ b/app/admin/dpa_exceptions.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register DpaException do
+  menu parent: 'Main Tables', priority: 1
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/admin/dpa_exceptions.rb
+++ b/app/admin/dpa_exceptions.rb
@@ -15,5 +15,8 @@ ActiveAdmin.register DpaException do
   #   permitted << :other if params[:action] == 'create' && current_user.admin?
   #   permitted
   # end
+
+  scope :archived
+  scope :active, :default => true
   
 end

--- a/app/admin/it_security_incident_statuses.rb
+++ b/app/admin/it_security_incident_statuses.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register ItSecurityIncidentStatus do
+  menu parent: 'Complementary Tables', priority: 1
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/admin/it_security_incidents.rb
+++ b/app/admin/it_security_incidents.rb
@@ -16,4 +16,7 @@ ActiveAdmin.register ItSecurityIncident do
   #   permitted
   # end
   
+  scope :archived
+  scope :active, :default => true
+  
 end

--- a/app/admin/it_security_incidents.rb
+++ b/app/admin/it_security_incidents.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register ItSecurityIncident do
+  menu parent: 'Main Tables', priority: 1
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/admin/legacy_os_records.rb
+++ b/app/admin/legacy_os_records.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register LegacyOsRecord do
+  menu parent: 'Main Tables', priority: 1
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/admin/legacy_os_records.rb
+++ b/app/admin/legacy_os_records.rb
@@ -16,4 +16,7 @@ ActiveAdmin.register LegacyOsRecord do
   #   permitted
   # end
   
+  scope :archived
+  scope :active, :default => true
+  
 end

--- a/app/admin/sensitive_data_systems.rb
+++ b/app/admin/sensitive_data_systems.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register SensitiveDataSystem do
+  menu parent: 'Main Tables', priority: 1
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/admin/sensitive_data_systems.rb
+++ b/app/admin/sensitive_data_systems.rb
@@ -16,4 +16,7 @@ ActiveAdmin.register SensitiveDataSystem do
   #   permitted
   # end
   
+  scope :archived
+  scope :active, :default => true
+  
 end

--- a/app/admin/storage_locations.rb
+++ b/app/admin/storage_locations.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register StorageLocation do
+  menu parent: 'Complementary Tables', priority: 1
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register User do
+  menu parent: 'Logins Info', priority: 1
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,9 @@
 class ApplicationController < ActionController::Base
-    include Pundit
-    rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
-    private
+  include Pundit
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  private
 
   def user_not_authorized
     flash[:alert] = "You are not authorized to perform this action."

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -1,4 +1,6 @@
 class DevicesController < InheritedResources::Base
+  devise_group :logged_in, contains: [:user, :admin_user]
+  before_action :authenticate_logged_in!
 
   require 'uri'
   require 'net/http'

--- a/app/controllers/dpa_exceptions_controller.rb
+++ b/app/controllers/dpa_exceptions_controller.rb
@@ -1,17 +1,20 @@
 class DpaExceptionsController < InheritedResources::Base
+  devise_group :logged_in, contains: [:user, :admin]
+  before_action :authenticate_logged_in!
 
-  def destroy
+  def index
+    @dpa_exceptions = DpaException.active
+  end
+
+  def archive
     @dpa_exception = DpaException.find(params[:id])
     authorize @dpa_exception
-    
-    if @dpa_exception.destroy
-      flash[:notice] = "\"#{@dpa_exception.id}\" was successfully deleted."
-      redirect_to @dpa_exception
-    else
-      flash.now[:alert] = "There was an error deleting the dpa_exception."
-      render :show
+    @dpa_exception.archive
+    respond_to do |format|
+      format.html { redirect_to dpa_exceptions_path, notice: 'dpa exception record was successfully archived.' }
+      format.json { head :no_content }
     end
-  end 
+  end
   
   def audit_log
     @dpa_exceptions = DpaException.all

--- a/app/controllers/dpa_exceptions_controller.rb
+++ b/app/controllers/dpa_exceptions_controller.rb
@@ -1,5 +1,5 @@
 class DpaExceptionsController < InheritedResources::Base
-  devise_group :logged_in, contains: [:user, :admin]
+  devise_group :logged_in, contains: [:user, :admin_user]
   before_action :authenticate_logged_in!
 
   def index
@@ -9,9 +9,13 @@ class DpaExceptionsController < InheritedResources::Base
   def archive
     @dpa_exception = DpaException.find(params[:id])
     authorize @dpa_exception
-    @dpa_exception.archive
-    respond_to do |format|
-      format.html { redirect_to dpa_exceptions_path, notice: 'dpa exception record was successfully archived.' }
+    if @dpa_exception.archive
+      respond_to do |format|
+        format.html { redirect_to dpa_exceptions_path, notice: 'dpa exception record was successfully archived.' }
+        format.json { head :no_content }
+      end
+    else
+      format.html { redirect_to dpa_exceptions_path, alert: 'error archiving dpa exception record.' }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/it_security_incidents_controller.rb
+++ b/app/controllers/it_security_incidents_controller.rb
@@ -1,4 +1,24 @@
 class ItSecurityIncidentsController < InheritedResources::Base
+  devise_group :logged_in, contains: [:user, :admin]
+  before_action :authenticate_logged_in!
+
+  def index
+    @it_security_incidents = ItSecurityIncident.active
+  end
+
+  def archive
+    @it_security_incident = ItSecurityIncident.find(params[:id])
+    authorize @it_security_incident
+    @it_security_incident.archive
+    respond_to do |format|
+      format.html { redirect_to it_security_incidents_path, notice: 'it security incident record was successfully archived.' }
+      format.json { head :no_content }
+    end
+  end
+  
+  def audit_log
+    @it_security_incidents = ItSecurityIncident.all
+  end
 
   private
 

--- a/app/controllers/it_security_incidents_controller.rb
+++ b/app/controllers/it_security_incidents_controller.rb
@@ -1,5 +1,5 @@
 class ItSecurityIncidentsController < InheritedResources::Base
-  devise_group :logged_in, contains: [:user, :admin]
+  devise_group :logged_in, contains: [:user, :admin_user]
   before_action :authenticate_logged_in!
 
   def index
@@ -9,9 +9,13 @@ class ItSecurityIncidentsController < InheritedResources::Base
   def archive
     @it_security_incident = ItSecurityIncident.find(params[:id])
     authorize @it_security_incident
-    @it_security_incident.archive
-    respond_to do |format|
-      format.html { redirect_to it_security_incidents_path, notice: 'it security incident record was successfully archived.' }
+    if @it_security_incident.archive
+      respond_to do |format|
+        format.html { redirect_to it_security_incidents_path, notice: 'it security incident record was successfully archived.' }
+        format.json { head :no_content }
+      end
+    else
+      format.html { redirect_to it_security_incidents_path, alert: 'error archiving it security incident record.' }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/legacy_os_records_controller.rb
+++ b/app/controllers/legacy_os_records_controller.rb
@@ -1,4 +1,24 @@
 class LegacyOsRecordsController < InheritedResources::Base
+  devise_group :logged_in, contains: [:user, :admin]
+  before_action :authenticate_logged_in!
+
+  def index
+    @legacy_os_records = LegacyOsRecord.active
+  end
+
+  def archive
+    @legacy_os_record = LegacyOsRecord.find(params[:id])
+    authorize @legacy_os_record
+    @legacy_os_record.archive
+    respond_to do |format|
+      format.html { redirect_to legacy_os_records_path, notice: 'legacy os record record was successfully archived.' }
+      format.json { head :no_content }
+    end
+  end
+  
+  def audit_log
+    @legacy_os_records = LegacyOsRecord.all
+  end
 
   private
 

--- a/app/controllers/legacy_os_records_controller.rb
+++ b/app/controllers/legacy_os_records_controller.rb
@@ -1,5 +1,5 @@
 class LegacyOsRecordsController < InheritedResources::Base
-  devise_group :logged_in, contains: [:user, :admin]
+  devise_group :logged_in, contains: [:user, :admin_user]
   before_action :authenticate_logged_in!
 
   def index
@@ -9,9 +9,13 @@ class LegacyOsRecordsController < InheritedResources::Base
   def archive
     @legacy_os_record = LegacyOsRecord.find(params[:id])
     authorize @legacy_os_record
-    @legacy_os_record.archive
-    respond_to do |format|
-      format.html { redirect_to legacy_os_records_path, notice: 'legacy os record record was successfully archived.' }
+    if @legacy_os_record.archive
+      respond_to do |format|
+        format.html { redirect_to legacy_os_records_path, notice: 'legacy os record was successfully archived.' }
+        format.json { head :no_content }
+      end
+    else
+      format.html { redirect_to legacy_os_records_path, alert: 'error archiving legacy os record.' }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/sensitive_data_systems_controller.rb
+++ b/app/controllers/sensitive_data_systems_controller.rb
@@ -1,5 +1,5 @@
 class SensitiveDataSystemsController < InheritedResources::Base
-  devise_group :logged_in, contains: [:user, :admin]
+  devise_group :logged_in, contains: [:user, :admin_user]
   before_action :authenticate_logged_in!
 
   def index
@@ -9,9 +9,13 @@ class SensitiveDataSystemsController < InheritedResources::Base
   def archive
     @sensitive_data_system = SensitiveDataSystem.find(params[:id])
     authorize @sensitive_data_system
-    @sensitive_data_system.archive
-    respond_to do |format|
-      format.html { redirect_to sensitive_data_systems_path, notice: 'sensitive data system record was successfully archived.' }
+    if @sensitive_data_system.archive
+      respond_to do |format|
+        format.html { redirect_to sensitive_data_systems_path, notice: 'sensitive data system record was successfully archived.' }
+        format.json { head :no_content }
+      end
+    else
+      format.html { redirect_to sensitive_data_systems_path, alert: 'error archiving sensitive data system record.' }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/sensitive_data_systems_controller.rb
+++ b/app/controllers/sensitive_data_systems_controller.rb
@@ -1,4 +1,24 @@
 class SensitiveDataSystemsController < InheritedResources::Base
+  devise_group :logged_in, contains: [:user, :admin]
+  before_action :authenticate_logged_in!
+
+  def index
+    @sensitive_data_systems = SensitiveDataSystem.active
+  end
+
+  def archive
+    @sensitive_data_system = SensitiveDataSystem.find(params[:id])
+    authorize @sensitive_data_system
+    @sensitive_data_system.archive
+    respond_to do |format|
+      format.html { redirect_to sensitive_data_systems_path, notice: 'sensitive data system record was successfully archived.' }
+      format.json { head :no_content }
+    end
+  end
+  
+  def audit_log
+    @sensitive_data_systems = SensitiveDataSystem.all
+  end
 
   private
 

--- a/app/models/dpa_exception.rb
+++ b/app/models/dpa_exception.rb
@@ -19,6 +19,7 @@
 #  data_type_id                     :bigint           not null
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
+#  deleted_at                       :datetime
 #
 class DpaException < ApplicationRecord
   belongs_to :data_type

--- a/app/models/dpa_exception.rb
+++ b/app/models/dpa_exception.rb
@@ -27,4 +27,16 @@ class DpaException < ApplicationRecord
   has_many_attached :attachments
   has_one_attached :sla_attachment
   audited
+
+  scope :active, -> { where(deleted_at: nil) }
+  scope :archived, -> { where("#{self.table_name}.deleted_at IS NOT NULL") }
+
+  def archive
+    self.update(deleted_at: DateTime.current)
+  end
+
+  def archived?
+    self.deleted_at.present?
+  end
+  
 end

--- a/app/models/it_security_incident.rb
+++ b/app/models/it_security_incident.rb
@@ -13,6 +13,7 @@
 #  data_type_id                   :bigint           not null
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
+#  deleted_at                     :datetime
 #
 class ItSecurityIncident < ApplicationRecord
   belongs_to :it_security_incident_status

--- a/app/models/it_security_incident.rb
+++ b/app/models/it_security_incident.rb
@@ -21,4 +21,16 @@ class ItSecurityIncident < ApplicationRecord
   has_many :tdx_tickets, as: :records_to_tdx
   has_many_attached :attachments
   audited
+
+  scope :active, -> { where(deleted_at: nil) }
+  scope :archived, -> { where("#{self.table_name}.deleted_at IS NOT NULL") }
+
+  def archive
+    self.update(deleted_at: DateTime.current)
+  end
+
+  def archived?
+    self.deleted_at.present?
+  end
+  
 end

--- a/app/models/legacy_os_record.rb
+++ b/app/models/legacy_os_record.rb
@@ -25,6 +25,7 @@
 #  device_id                     :bigint           not null
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
+#  deleted_at                    :datetime
 #
 class LegacyOsRecord < ApplicationRecord
   belongs_to :data_type

--- a/app/models/legacy_os_record.rb
+++ b/app/models/legacy_os_record.rb
@@ -34,4 +34,16 @@ class LegacyOsRecord < ApplicationRecord
 
   has_many_attached :attachments
   audited
+
+  scope :active, -> { where(deleted_at: nil) }
+  scope :archived, -> { where("#{self.table_name}.deleted_at IS NOT NULL") }
+
+  def archive
+    self.update(deleted_at: DateTime.current)
+  end
+
+  def archived?
+    self.deleted_at.present?
+  end
+  
 end

--- a/app/models/sensitive_data_system.rb
+++ b/app/models/sensitive_data_system.rb
@@ -20,6 +20,7 @@
 #  device_id                           :bigint           not null
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
+#  deleted_at                          :datetime
 #
 class SensitiveDataSystem < ApplicationRecord
   belongs_to :storage_location

--- a/app/models/sensitive_data_system.rb
+++ b/app/models/sensitive_data_system.rb
@@ -31,4 +31,15 @@ class SensitiveDataSystem < ApplicationRecord
   has_many_attached :attachments
   audited
 
+  scope :active, -> { where(deleted_at: nil) }
+  scope :archived, -> { where("#{self.table_name}.deleted_at IS NOT NULL") }
+
+  def archive
+    self.update(deleted_at: DateTime.current)
+  end
+
+  def archived?
+    self.deleted_at.present?
+  end
+
 end

--- a/app/policies/dpa_exception_policy.rb
+++ b/app/policies/dpa_exception_policy.rb
@@ -5,10 +5,6 @@ class DpaExceptionPolicy
       @user = user
       @dpa_exception = dpa_exception
     end
-  
-    # def update?
-    #   user.user? 
-    # end
 
     def archive?
         user.role == 'can_delete'

--- a/app/policies/dpa_exception_policy.rb
+++ b/app/policies/dpa_exception_policy.rb
@@ -10,7 +10,7 @@ class DpaExceptionPolicy
     #   user.user? 
     # end
 
-    def destroy?
+    def archive?
         user.role == 'can_delete'
       end
   end

--- a/app/policies/it_security_incident_policy.rb
+++ b/app/policies/it_security_incident_policy.rb
@@ -1,0 +1,16 @@
+class ItSecurityIncidentPolicy
+    attr_reader :user, :it_security_incident
+  
+    def initialize(user, it_security_incident)
+      @user = user
+      @it_security_incident = it_security_incident
+    end
+  
+    # def update?
+    #   user.user? 
+    # end
+
+    def archive?
+        user.role == 'can_delete'
+      end
+  end

--- a/app/policies/it_security_incident_policy.rb
+++ b/app/policies/it_security_incident_policy.rb
@@ -5,10 +5,6 @@ class ItSecurityIncidentPolicy
       @user = user
       @it_security_incident = it_security_incident
     end
-  
-    # def update?
-    #   user.user? 
-    # end
 
     def archive?
         user.role == 'can_delete'

--- a/app/policies/legacy_os_record_policy.rb
+++ b/app/policies/legacy_os_record_policy.rb
@@ -5,10 +5,6 @@ class LegacyOsRecordPolicy
       @user = user
       @legacy_os_record = legacy_os_record
     end
-  
-    # def update?
-    #   user.user? 
-    # end
 
     def archive?
         user.role == 'can_delete'

--- a/app/policies/legacy_os_record_policy.rb
+++ b/app/policies/legacy_os_record_policy.rb
@@ -1,0 +1,16 @@
+class LegacyOsRecordPolicy
+    attr_reader :user, :legacy_os_record
+  
+    def initialize(user, legacy_os_record)
+      @user = user
+      @legacy_os_record = legacy_os_record
+    end
+  
+    # def update?
+    #   user.user? 
+    # end
+
+    def archive?
+        user.role == 'can_delete'
+      end
+  end

--- a/app/policies/sensitive_data_system_policy.rb
+++ b/app/policies/sensitive_data_system_policy.rb
@@ -1,0 +1,16 @@
+class SensitiveDataSystemPolicy
+    attr_reader :user, :sensitive_data_system
+  
+    def initialize(user, sensitive_data_system)
+      @user = user
+      @sensitive_data_system = sensitive_data_system
+    end
+  
+    # def update?
+    #   user.user? 
+    # end
+
+    def archive?
+        user.role == 'can_delete'
+      end
+  end

--- a/app/policies/sensitive_data_system_policy.rb
+++ b/app/policies/sensitive_data_system_policy.rb
@@ -6,10 +6,6 @@ class SensitiveDataSystemPolicy
       @sensitive_data_system = sensitive_data_system
     end
   
-    # def update?
-    #   user.user? 
-    # end
-
     def archive?
         user.role == 'can_delete'
       end

--- a/app/views/dpa_exceptions/index.html.erb
+++ b/app/views/dpa_exceptions/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Dpa Exceptions</h1>
 
 <table>
@@ -42,7 +40,7 @@
         <td><%= dpa_exception.data_type_id %></td>
         <td><%= link_to 'Show', dpa_exception %></td>
         <td><%= link_to 'Edit', edit_dpa_exception_path(dpa_exception) %></td>
-        <td><%= link_to 'Destroy', dpa_exception, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Archive', archive_dpa_exception_path(dpa_exception), method: :post, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/it_security_incidents/index.html.erb
+++ b/app/views/it_security_incidents/index.html.erb
@@ -28,7 +28,6 @@
         <td><%= it_security_incident.data_type_id %></td>
         <td><%= link_to 'Show', it_security_incident %></td>
         <td><%= link_to 'Edit', edit_it_security_incident_path(it_security_incident) %></td>
-        <td><%= link_to 'Destroy', it_security_incident, method: :delete, data: { confirm: 'Are you sure?' } %></td>
         <td><%= link_to 'Archive', archive_it_security_incident_path(it_security_incident), method: :post, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/it_security_incidents/index.html.erb
+++ b/app/views/it_security_incidents/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>It Security Incidents</h1>
 
 <table>
@@ -31,6 +29,7 @@
         <td><%= link_to 'Show', it_security_incident %></td>
         <td><%= link_to 'Edit', edit_it_security_incident_path(it_security_incident) %></td>
         <td><%= link_to 'Destroy', it_security_incident, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Archive', archive_it_security_incident_path(it_security_incident), method: :post, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -24,20 +24,22 @@
           <%= link_to "Terms of Use", terms_path %>
         </a>
       </div>
-      <div>
-        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
-          <%= link_to "| DPA Exceptions | ", dpa_exceptions_path %>
-        </a>
-        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
-          <%= link_to "It Security Incidents | ", it_security_incidents_path %>
-        </a>
-        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
-          <%= link_to "Legacy Os Record | ", legacy_os_records_path %>
-        </a>
-        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
-          <%= link_to "Sensitive Data System | ", sensitive_data_systems_path %>
-        </a>
-      </div>
+      <% if user_signed_in? or admin_user_signed_in? %>
+        <div>
+          <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
+            <%= link_to "| DPA Exceptions | ", dpa_exceptions_path %>
+          </a>
+          <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
+            <%= link_to "It Security Incidents | ", it_security_incidents_path %>
+          </a>
+          <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
+            <%= link_to "Legacy Os Record | ", legacy_os_records_path %>
+          </a>
+          <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
+            <%= link_to "Sensitive Data System | ", sensitive_data_systems_path %>
+          </a>
+        </div>
+      <% end %>
       <div>
         &nbsp;&nbsp;
       </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -24,6 +24,23 @@
           <%= link_to "Terms of Use", terms_path %>
         </a>
       </div>
+      <div>
+        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
+          <%= link_to "| DPA Exceptions | ", dpa_exceptions_path %>
+        </a>
+        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
+          <%= link_to "It Security Incidents | ", it_security_incidents_path %>
+        </a>
+        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
+          <%= link_to "Legacy Os Record | ", legacy_os_records_path %>
+        </a>
+        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white">
+          <%= link_to "Sensitive Data System | ", sensitive_data_systems_path %>
+        </a>
+      </div>
+      <div>
+        &nbsp;&nbsp;
+      </div>
       <div class="w-full block flex sm:items-center sm:w-auto">
       <div class= "flex justify-end">
         <% if user_signed_in? %>

--- a/app/views/legacy_os_records/index.html.erb
+++ b/app/views/legacy_os_records/index.html.erb
@@ -52,7 +52,6 @@
         <td><%= legacy_os_record.device_id %></td>
         <td><%= link_to 'Show', legacy_os_record %></td>
         <td><%= link_to 'Edit', edit_legacy_os_record_path(legacy_os_record) %></td>
-        <td><%= link_to 'Destroy', legacy_os_record, method: :delete, data: { confirm: 'Are you sure?' } %></td>
         <td><%= link_to 'Archive', archive_legacy_os_record_path(legacy_os_record), method: :post, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/legacy_os_records/index.html.erb
+++ b/app/views/legacy_os_records/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Legacy Os Records</h1>
 
 <table>
@@ -55,6 +53,7 @@
         <td><%= link_to 'Show', legacy_os_record %></td>
         <td><%= link_to 'Edit', edit_legacy_os_record_path(legacy_os_record) %></td>
         <td><%= link_to 'Destroy', legacy_os_record, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Archive', archive_legacy_os_record_path(legacy_os_record), method: :post, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/sensitive_data_systems/index.html.erb
+++ b/app/views/sensitive_data_systems/index.html.erb
@@ -42,7 +42,6 @@
         <td><%= sensitive_data_system.device_id %></td>
         <td><%= link_to 'Show', sensitive_data_system %></td>
         <td><%= link_to 'Edit', edit_sensitive_data_system_path(sensitive_data_system) %></td>
-        <td><%= link_to 'Destroy', sensitive_data_system, method: :delete, data: { confirm: 'Are you sure?' } %></td>
         <td><%= link_to 'Archive', archive_sensitive_data_system_path(sensitive_data_system), method: :post, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/sensitive_data_systems/index.html.erb
+++ b/app/views/sensitive_data_systems/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Sensitive Data Systems</h1>
 
 <table>
@@ -45,6 +43,7 @@
         <td><%= link_to 'Show', sensitive_data_system %></td>
         <td><%= link_to 'Edit', edit_sensitive_data_system_path(sensitive_data_system) %></td>
         <td><%= link_to 'Destroy', sensitive_data_system, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Archive', archive_sensitive_data_system_path(sensitive_data_system), method: :post, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,19 @@
 Rails.application.routes.draw do
   devise_for :users
+
+  post 'archive_it_security_incident/:id', to: 'it_security_incidents#archive', as: :archive_it_security_incident
   resources :it_security_incidents
+
+  post 'archive_sensitive_data_system/:id', to: 'sensitive_data_systems#archive', as: :archive_sensitive_data_system
   resources :sensitive_data_systems
+
+  post 'archive_legacy_os_record/:id', to: 'legacy_os_records#archive', as: :archive_legacy_os_record
   resources :legacy_os_records
+
   get 'dpa_exceptions/audit_log', to: 'dpa_exceptions#audit_log'
+  post 'archive_dpa_exception/:id', to: 'dpa_exceptions#archive', as: :archive_dpa_exception
   resources :dpa_exceptions
+
   resources :devices
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)

--- a/db/migrate/20210423123300_add_deleted_at_to_dpa_exception.rb
+++ b/db/migrate/20210423123300_add_deleted_at_to_dpa_exception.rb
@@ -1,0 +1,8 @@
+class AddDeletedAtToDpaException < ActiveRecord::Migration[6.1]
+  def change
+    add_column :dpa_exceptions, :deleted_at, :datetime
+    add_column :it_security_incidents, :deleted_at, :datetime
+    add_column :legacy_os_records, :deleted_at, :datetime
+    add_column :sensitive_data_systems, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_21_183243) do
+ActiveRecord::Schema.define(version: 2021_04_23_123300) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "namespace"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_183243) do
     t.bigint "data_type_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
     t.index ["data_type_id"], name: "index_dpa_exceptions_on_data_type_id"
   end
 
@@ -162,6 +163,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_183243) do
     t.bigint "data_type_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
     t.index ["data_type_id"], name: "index_it_security_incidents_on_data_type_id"
     t.index ["it_security_incident_status_id"], name: "index_it_security_incidents_on_it_security_incident_status_id"
   end
@@ -189,6 +191,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_183243) do
     t.bigint "device_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
     t.index ["data_type_id"], name: "index_legacy_os_records_on_data_type_id"
     t.index ["device_id"], name: "index_legacy_os_records_on_device_id"
   end
@@ -211,6 +214,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_183243) do
     t.bigint "device_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
     t.index ["data_type_id"], name: "index_sensitive_data_systems_on_data_type_id"
     t.index ["device_id"], name: "index_sensitive_data_systems_on_device_id"
     t.index ["storage_location_id"], name: "index_sensitive_data_systems_on_storage_location_id"

--- a/spec/factories/dpa_exceptions.rb
+++ b/spec/factories/dpa_exceptions.rb
@@ -19,6 +19,7 @@
 #  data_type_id                     :bigint           not null
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
+#  deleted_at                       :datetime
 #
 FactoryBot.define do
   factory :dpa_exception do

--- a/spec/factories/it_security_incidents.rb
+++ b/spec/factories/it_security_incidents.rb
@@ -13,6 +13,7 @@
 #  data_type_id                   :bigint           not null
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
+#  deleted_at                     :datetime
 #
 FactoryBot.define do
   factory :it_security_incident do

--- a/spec/factories/legacy_os_records.rb
+++ b/spec/factories/legacy_os_records.rb
@@ -25,6 +25,7 @@
 #  device_id                     :bigint           not null
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
+#  deleted_at                    :datetime
 #
 FactoryBot.define do
   factory :legacy_os_record do

--- a/spec/factories/sensitive_data_systems.rb
+++ b/spec/factories/sensitive_data_systems.rb
@@ -20,6 +20,7 @@
 #  device_id                           :bigint           not null
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
+#  deleted_at                          :datetime
 #
 FactoryBot.define do
   factory :sensitive_data_system do

--- a/spec/models/dpa_exception_spec.rb
+++ b/spec/models/dpa_exception_spec.rb
@@ -19,6 +19,7 @@
 #  data_type_id                     :bigint           not null
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
+#  deleted_at                       :datetime
 #
 require 'rails_helper'
 

--- a/spec/models/it_security_incident_spec.rb
+++ b/spec/models/it_security_incident_spec.rb
@@ -13,6 +13,7 @@
 #  data_type_id                   :bigint           not null
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
+#  deleted_at                     :datetime
 #
 require 'rails_helper'
 

--- a/spec/models/legacy_os_record_spec.rb
+++ b/spec/models/legacy_os_record_spec.rb
@@ -25,6 +25,7 @@
 #  device_id                     :bigint           not null
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
+#  deleted_at                    :datetime
 #
 require 'rails_helper'
 

--- a/spec/models/sensitive_data_system_spec.rb
+++ b/spec/models/sensitive_data_system_spec.rb
@@ -20,6 +20,7 @@
 #  device_id                           :bigint           not null
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
+#  deleted_at                          :datetime
 #
 require 'rails_helper'
 


### PR DESCRIPTION
In addition to creating an archive method to replace the destroy one, I added 
- main tables' links to the header,
- authorize policies for the archive action, 
- required before_action authentication in controllers,
and reorganized the active admin navigation menu.