### PR TITLE
Add links to device's show page for legacy os records

### DIFF
--- a/app/views/legacy_os_records/show.html.erb
+++ b/app/views/legacy_os_records/show.html.erb
@@ -101,7 +101,7 @@
 
 <p>
   <strong>Device:</strong>
-  <%= @legacy_os_record.device.display_name %>
+  <%= link_to @legacy_os_record.device.display_name, device_path(@legacy_os_record.device.id), target: :_blank %>
 </p>
 
 <%= render partial: "partials/show_attachments", locals: {attached_files: @legacy_os_record}, show_p: "legacy_os_record" %>

--- a/app/views/sensitive_data_systems/_form.html.erb
+++ b/app/views/sensitive_data_systems/_form.html.erb
@@ -118,11 +118,6 @@
           <% end %>
         </div>
       <% end %>
-
-        <div class="field">
-          <%= form.label :sensitive_data_system_type_id %><font color="red">**</font>
-          <%= form.collection_select :sensitive_data_system_type_id, SensitiveDataSystemType.all, :id, :name, {include_blank: "Select"}, required: true, :"data-sensitiveds-target" => "sensitive_data_system_type", :"data-action" => "input->sensitiveds#display_device" %>
-        </div>
   
         <div id="device_input" class="device--hide" data-sensitiveds-target="system_device">
           <%= form.label "Add a device" %><font color="red">**</font> - enter serial:

--- a/app/views/sensitive_data_systems/show.html.erb
+++ b/app/views/sensitive_data_systems/show.html.erb
@@ -74,15 +74,10 @@
   <%= @sensitive_data_system.data_type_id %>
 </p>
 
-<p>
-  <strong>System Type:</strong>
-  <%= @sensitive_data_system.sensitive_data_system_type_id %>
-</p>
-
 <% if @sensitive_data_system.device_id.present? %>
   <p>
     <strong>Device:</strong>
-    <%= @sensitive_data_system.device.display_name %>
+    <%= link_to @sensitive_data_system.device.display_name, device_path(@sensitive_data_system.device.id), target: :_blank %>
   </p>
 <% end %>
 


### PR DESCRIPTION
In show views (for legacy os records and sensitive data systems) replaced display names for a device with a link to the device's show page.
We can do the same for index views, but I don't think we should (unless they ask when start using the system).