### PR TITLE
Improve authorisation process

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :set_breadcrumbs
+  before_action :set_membership
 
   include Pagy::Backend
 

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -4,7 +4,6 @@ class DevicesController < InheritedResources::Base
   before_action :authenticate_logged_in!
   before_action :set_device, only: [:show, :edit, :update]
   before_action :add_index_breadcrumb, only: [:index, :show, :new, :edit]
-  before_action :set_membership
 
   def index
     @pagy, @devices = pagy(Device.all)

--- a/app/controllers/dpa_exceptions_controller.rb
+++ b/app/controllers/dpa_exceptions_controller.rb
@@ -5,7 +5,6 @@ class DpaExceptionsController < InheritedResources::Base
   before_action :authenticate_logged_in!
   before_action :set_dpa_exception, only: [:show, :edit, :update, :archive, :audit_log]
   before_action :add_index_breadcrumb, only: [:index, :show, :new, :edit, :audit_log]
-  before_action :set_membership
 
   def index
 

--- a/app/controllers/it_security_incidents_controller.rb
+++ b/app/controllers/it_security_incidents_controller.rb
@@ -4,7 +4,6 @@ class ItSecurityIncidentsController < InheritedResources::Base
   before_action :authenticate_logged_in!
   before_action :set_it_security_incident, only: [:show, :edit, :update, :archive, :audit_log]
   before_action :add_index_breadcrumb, only: [:index, :show, :new, :edit, :audit_log]
-  before_action :set_membership
 
   def index
 

--- a/app/controllers/legacy_os_records_controller.rb
+++ b/app/controllers/legacy_os_records_controller.rb
@@ -5,7 +5,6 @@ class LegacyOsRecordsController < InheritedResources::Base
   before_action :set_legacy_os_record, only: [:show, :edit, :update, :archive, :audit_log]
   before_action :get_access_token, only: [:create, :update]
   before_action :add_index_breadcrumb, only: [:index, :show, :new, :edit, :audit_log]
-  before_action :set_membership
 
   def index
 

--- a/app/controllers/sensitive_data_systems_controller.rb
+++ b/app/controllers/sensitive_data_systems_controller.rb
@@ -5,7 +5,6 @@ class SensitiveDataSystemsController < InheritedResources::Base
   before_action :set_sensitive_data_system, only: [:show, :edit, :update, :archive, :audit_log]
   before_action :get_access_token, only: [:create, :update]
   before_action :add_index_breadcrumb, only: [:index, :show, :new, :edit, :audit_log]
-  before_action :set_membership
 
   def index
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,24 +2,6 @@ module ApplicationHelper
   
   include Pagy::Frontend
 
-  def has_ad_access?(user, table, action=nil)
-    user.membership = session[:user_memberships]
-    # logger.debug "*********************************user.membership: #{user.membership}"
-    # logger.debug "*********************************has_ad_access: #{action}"
-    case action
-    when  'newedit_action',
-          'show_action',
-          'archive_action',
-          'audit_action'
-      ldap_groups = AccessLookup.where(table: table, action: action).or(AccessLookup.where(table: table, action: 'all_actions')).pluck(:ldap_group)
-    when nil
-      ldap_groups = AccessLookup.where(table: table).pluck(:ldap_group)
-    else
-      ldap_groups = []
-    end
-    (user.membership & ldap_groups).any?
-  end
-
   def show_data_type_name(resource)
     if resource.data_type
       resource.data_type.display_name

--- a/app/policies/dpa_exception_policy.rb
+++ b/app/policies/dpa_exception_policy.rb
@@ -35,4 +35,10 @@ class DpaExceptionPolicy < ApplicationPolicy
       get_ldap_groups('dpa_exceptions', 'audit_action')
       (user.membership & @ldap_groups).any?
     end
+
+    def any_action?
+      get_ldap_groups('dpa_exceptions')
+      (user.membership & @ldap_groups).any?
+    end
+
   end

--- a/app/policies/it_security_incident_policy.rb
+++ b/app/policies/it_security_incident_policy.rb
@@ -35,4 +35,10 @@ class ItSecurityIncidentPolicy < ApplicationPolicy
       get_ldap_groups('it_security_incidents', 'audit_action')
       (user.membership & @ldap_groups).any?
     end
+
+    def any_action?
+      get_ldap_groups('it_security_incidents')
+      (user.membership & @ldap_groups).any?
+    end
+
   end

--- a/app/policies/legacy_os_record_policy.rb
+++ b/app/policies/legacy_os_record_policy.rb
@@ -35,4 +35,10 @@ class LegacyOsRecordPolicy < ApplicationPolicy
       get_ldap_groups('legacy_os_records', 'audit_action')
       (user.membership & @ldap_groups).any?
     end
+
+    def any_action?
+      get_ldap_groups('legacy_os_records')
+      (user.membership & @ldap_groups).any?
+    end
+
   end

--- a/app/policies/sensitive_data_system_policy.rb
+++ b/app/policies/sensitive_data_system_policy.rb
@@ -35,4 +35,10 @@ class SensitiveDataSystemPolicy < ApplicationPolicy
       get_ldap_groups('sensitive_data_systems', 'audit_action')
       (user.membership & @ldap_groups).any?
     end
+
+    def any_action?
+      get_ldap_groups('sensitive_data_systems')
+      (user.membership & @ldap_groups).any?
+    end
+
   end

--- a/app/views/devices/show.html.erb
+++ b/app/views/devices/show.html.erb
@@ -122,7 +122,7 @@
   </dl>
 </div>
 
-<% if has_ad_access?(current_user, "devices", "newedit_action") %>
+<% if policy(@device).edit? %>
   <%= link_to 'Update', update_device_path(@device), class: "action-link" %>
 <% end %>
 

--- a/app/views/dpa_exceptions/_listing.html.erb
+++ b/app/views/dpa_exceptions/_listing.html.erb
@@ -31,14 +31,14 @@
                 <td>
                 <ul>
                     <li><%= link_to 'Show', dpa_exception, class: "action-link" %></li>
-                    <% if has_ad_access?(current_user, "dpa_exceptions", "newedit_action") %>
-                    <li><%= link_to 'Edit', edit_dpa_exception_path(dpa_exception), class: "action-link" %></li>
+                    <% if policy(dpa_exception).edit? %>
+                      <li><%= link_to 'Edit', edit_dpa_exception_path(dpa_exception), class: "action-link" %></li>
                     <% end %>
-                    <% if has_ad_access?(current_user, "dpa_exceptions", "archive_action") %>
-                    <li><%= link_to 'Archive', archive_dpa_exception_path(dpa_exception), class: "action-link",  method: :post, data: { confirm: 'Are you sure?' } %></li>
+                    <% if policy(dpa_exception).archive? %>
+                      <li><%= link_to 'Archive', archive_dpa_exception_path(dpa_exception), class: "action-link",  method: :post, data: { confirm: 'Are you sure?' } %></li>
                     <% end %>
-                    <% if has_ad_access?(current_user, "dpa_exceptions", "audit_action") %>
-                    <li><%= link_to 'Audit', dpa_exception_audit_log_path(dpa_exception), class: "action-link" %></li>
+                    <% if policy(dpa_exception).audit_log? %>
+                      <li><%= link_to 'Audit', dpa_exception_audit_log_path(dpa_exception), class: "action-link" %></li>
                     <% end %>
                 </ul>
                 </td> 

--- a/app/views/dpa_exceptions/index.html.erb
+++ b/app/views/dpa_exceptions/index.html.erb
@@ -171,7 +171,7 @@
 </div>
 
 <div>
-  <% if has_ad_access?(current_user, "dpa_exceptions", "newedit_action") %>
+  <% if policy(@dpa_exceptions).new?  %>
     <div class="btn-new btn-blue" role="menu" aria-orientation="vertical" aria-labelledby="mobile-menu-button" tabindex="-1">
       <%= link_to 'New Dpa Exception', new_dpa_exception_path %>
     </div>

--- a/app/views/dpa_exceptions/show.html.erb
+++ b/app/views/dpa_exceptions/show.html.erb
@@ -33,13 +33,13 @@
   <span class="flex-grow"></span>
   <span class="ml-4 flex-shrink-0">
     <ul>
-      <% if has_ad_access?(current_user, "dpa_exceptions", "newedit_action") %>
+      <% if policy(@dpa_exception).edit? %>
         <li><%= link_to 'Edit', edit_dpa_exception_path(@dpa_exception), class: "action-link" %></li>
       <% end %>
-      <% if has_ad_access?(current_user, "dpa_exceptions", "archive_action") %>
+      <% if policy(@dpa_exception).archive? %>
         <li><%= link_to 'Archive', archive_dpa_exception_path(@dpa_exception), class: "action-link",  method: :post, data: { confirm: 'Are you sure?' } %></li>
       <% end %>
-      <% if has_ad_access?(current_user, "dpa_exceptions", "audit_action") %>
+      <% if policy(@dpa_exception).audit_log? %>
         <li><%= link_to 'Audit', dpa_exception_audit_log_path(@dpa_exception), class: "action-link" %></li>
       <% end %>
     </ul>
@@ -189,7 +189,7 @@
                 <%= link_to @dpa_exception.sla_attachment.filename, url_for(@dpa_exception.sla_attachment) %>
               </span>
             </div>
-            <% if has_ad_access?(current_user, "dpa_exceptions", "newedit_action") %>
+            <% if policy(@dpa_exception).edit? %>
               <div class="ml-4 flex-shrink-0 flex space-x-4">
                 <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                   <%= link_to 'Update', edit_dpa_exception_path(@dpa_exception, anchor: "sla_agreement_file") %>
@@ -206,7 +206,7 @@
                 you currently do not have an SLA Agreement attached.
               </span>
             </div>
-            <% if has_ad_access?(current_user, "dpa_exceptions", "newedit_action") %>
+            <% if policy(@dpa_exception).edit? %>
               <div class="ml-4 flex-shrink-0 flex space-x-4">
                 <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                   <%= link_to 'Add', edit_dpa_exception_path(@dpa_exception) %>

--- a/app/views/it_security_incidents/_listing.html.erb
+++ b/app/views/it_security_incidents/_listing.html.erb
@@ -30,13 +30,13 @@
               <td>
                 <ul>
                   <li><%= link_to 'Show', it_security_incident, class: "action-link" %></li>
-                  <% if has_ad_access?(current_user, "it_security_incidents", "newedit_action") %>
+                  <% if policy(it_security_incident).edit? %>
                     <li><%= link_to 'Edit', edit_it_security_incident_path(it_security_incident), class: "action-link" %></li>
                   <% end %>
-                  <% if has_ad_access?(current_user, "it_security_incidents", "archive_action") %>
+                  <% if policy(it_security_incident).archive? %>
                     <li><%= link_to 'Archive', archive_it_security_incident_path(it_security_incident), class: "action-link",  method: :post, data: { confirm: 'Are you sure?' } %></li>
                   <% end %>
-                  <% if has_ad_access?(current_user, "it_security_incidents", "audit_action") %>
+                  <% if policy(it_security_incident).audit_log? %>
                     <li><%= link_to 'Audit', it_security_incident_audit_log_path(it_security_incident), class: "action-link" %></li>
                   <% end %>
                 </ul>

--- a/app/views/it_security_incidents/index.html.erb
+++ b/app/views/it_security_incidents/index.html.erb
@@ -104,7 +104,7 @@
 </div>
 
 <div>
-  <% if has_ad_access?(current_user, "it_security_incidents", "newedit_action") %>
+  <% if policy(@it_security_incidents).new? %>
     <div class="btn-new btn-blue" role="menu" aria-orientation="vertical" aria-labelledby="mobile-menu-button" tabindex="-1">
       <%= link_to 'New It Security Incident', new_it_security_incident_path %>
     </div>

--- a/app/views/it_security_incidents/show.html.erb
+++ b/app/views/it_security_incidents/show.html.erb
@@ -33,13 +33,13 @@
     <span class="flex-grow"></span>
     <span class="ml-4 flex-shrink-0">
       <ul>
-        <% if has_ad_access?(current_user, "it_security_incidents", "newedit_action") %>
+        <% if policy(@it_security_incident).edit? %>
           <li><%= link_to 'Edit', edit_it_security_incident_path(@it_security_incident), class: "action-link" %></li>
         <% end %>
-        <% if has_ad_access?(current_user, "it_security_incidents", "archive_action") %>
+        <% if policy(@it_security_incident).archive? %>
           <li><%= link_to 'Archive', archive_it_security_incident_path(@it_security_incident), class: "action-link",  method: :post, data: { confirm: 'Are you sure?' } %></li>
         <% end %>
-        <% if has_ad_access?(current_user, "it_security_incidents", "audit_action") %>
+        <% if policy(@it_security_incident).audit_log? %>
           <li><%= link_to 'Audit', it_security_incident_audit_log_path(@it_security_incident), class: "action-link" %></li>
         <% end %>
       </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,16 +7,16 @@
       <div class="lg:flex-grow">
         <% if user_signed_in? %>
             <%= link_to "Dashboard", dashboard_path, class: "mr-4" %>
-            <% if has_ad_access?(current_user, "dpa_exceptions") %>
+            <% if policy(DpaException).any_action? %>
               <%= link_to "DPA Exceptions", dpa_exceptions_path, class: "mr-4" %>
             <% end %>
-            <% if has_ad_access?(current_user, "it_security_incidents") %>
+            <% if policy(ItSecurityIncident).any_action? %>
               <%= link_to "It Security Incidents", it_security_incidents_path, class: "mr-4" %>
             <% end %>
-            <% if has_ad_access?(current_user, "legacy_os_records") %>
+            <% if policy(LegacyOsRecord).any_action? %>
               <%= link_to "Legacy Os Record", legacy_os_records_path, class: "mr-4" %>
             <% end %>
-            <% if has_ad_access?(current_user, "sensitive_data_systems") %>
+            <% if policy(SensitiveDataSystem).any_action? %>
               <%= link_to "Sensitive Data System", sensitive_data_systems_path, class: "mr-4" %>
             <% end %>
         <% end %>

--- a/app/views/legacy_os_records/_listing.html.erb
+++ b/app/views/legacy_os_records/_listing.html.erb
@@ -41,14 +41,14 @@
               <td>
               <ul>
                 <li><%= link_to 'Show', legacy_os_record, class: "action-link" %></li>
-                <% if has_ad_access?(current_user, "legacy_os_records", "newedit_action") %>
-                <li><%= link_to 'Edit', edit_legacy_os_record_path(legacy_os_record), class: "action-link" %></li>
+                <% if policy(legacy_os_record).edit? %>
+                  <li><%= link_to 'Edit', edit_legacy_os_record_path(legacy_os_record), class: "action-link" %></li>
                 <% end %>
-                <% if has_ad_access?(current_user, "legacy_os_records", "archive_action") %>
-                <li><%= link_to 'Archive', archive_legacy_os_record_path(legacy_os_record), class: "action-link", method: :post, data: { confirm: 'Are you sure?' } %></li>
+                <% if policy(legacy_os_record).archive? %>
+                  <li><%= link_to 'Archive', archive_legacy_os_record_path(legacy_os_record), class: "action-link", method: :post, data: { confirm: 'Are you sure?' } %></li>
                 <% end %>
-                <% if has_ad_access?(current_user, "legacy_os_records", "audit_action") %>
-                <li><%= link_to 'Audit', legacy_os_record_audit_log_path(legacy_os_record), class: "action-link" %></li>
+                <% if policy(legacy_os_record).audit_log? %>
+                  <li><%= link_to 'Audit', legacy_os_record_audit_log_path(legacy_os_record), class: "action-link" %></li>
                 <% end %>
               </ul>
               </td>

--- a/app/views/legacy_os_records/index.html.erb
+++ b/app/views/legacy_os_records/index.html.erb
@@ -212,7 +212,7 @@
 
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-  <% if has_ad_access?(current_user, "legacy_os_records", "newedit_action") %>
+  <% if policy(@legacy_os_records).edit? %>
     <div class="btn-new btn-blue" role="menu" aria-orientation="vertical" aria-labelledby="mobile-menu-button" tabindex="-1">
       <%= link_to 'New Legacy Os Record', new_legacy_os_record_path %>
     </div>

--- a/app/views/legacy_os_records/show.html.erb
+++ b/app/views/legacy_os_records/show.html.erb
@@ -33,13 +33,13 @@
     <span class="flex-grow"></span>
     <span class="ml-4 flex-shrink-0">
       <ul>
-        <% if has_ad_access?(current_user, "legacy_os_records", "newedit_action") %>
+        <% if policy(@legacy_os_record).edit? %>
           <li><%= link_to 'Edit', edit_legacy_os_record_path(@legacy_os_record), class: "action-link" %></li>
         <% end %>
-        <% if has_ad_access?(current_user, "legacy_os_records", "archive_action") %>
+        <% if policy(@legacy_os_record).archive? %>
           <li><%= link_to 'Archive', archive_legacy_os_record_path(@legacy_os_record), class: "action-link",  method: :post, data: { confirm: 'Are you sure?' } %></li>
         <% end %>
-        <% if has_ad_access?(current_user, "legacy_os_records", "audit_action") %>
+        <% if policy(@legacy_os_record).audit_log? %>
           <li><%= link_to 'Audit', legacy_os_record_audit_log_path(@legacy_os_record), class: "action-link" %></li>
         <% end %>
       </ul>

--- a/app/views/partials/_show_attachments.html.erb
+++ b/app/views/partials/_show_attachments.html.erb
@@ -12,7 +12,7 @@
               <%= link_to file.filename, url_for(file) %>
             </span>
           </div>
-          <% if has_ad_access?(current_user, attached_files_resource.class.table_name, "newedit_action") %>
+          <% if policy(attached_files_resource).edit? %>
             <div class="ml-4 flex-shrink-0 flex space-x-4">
               <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                 <%= link_to "Update", "#{attached_files_resource.id}/edit#attached_files" %>
@@ -32,7 +32,7 @@
             you currently do not have an attached files.
           </span>
         </div>
-        <% if has_ad_access?(current_user, attached_files_resource.class.table_name, "newedit_action") %>
+        <% if policy(attached_files_resource).edit? %>
           <div class="ml-4 flex-shrink-0 flex space-x-4">
             <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
               <%= link_to "Add", "#{attached_files_resource.id}/edit" %>

--- a/app/views/sensitive_data_systems/_listing.html.erb
+++ b/app/views/sensitive_data_systems/_listing.html.erb
@@ -37,13 +37,13 @@
               <td>
                 <ul>
                   <li><%= link_to 'Show', sensitive_data_system, class: "action-link" %></li>
-                  <% if has_ad_access?(current_user, "sensitive_data_systems", "newedit_action") %>
+                  <% if policy(sensitive_data_system).edit? %>
                     <li><%= link_to 'Edit', edit_sensitive_data_system_path(sensitive_data_system), class: "action-link" %></li>
                   <% end %>
-                  <% if has_ad_access?(current_user, "sensitive_data_systems", "archive_action") %>
+                  <% if policy(sensitive_data_system).archive? %>
                     <li><%= link_to 'Archive', archive_sensitive_data_system_path(sensitive_data_system), class: "action-link", method: :post, data: { confirm: 'Are you sure?' } %></li>
                   <% end %>
-                  <% if has_ad_access?(current_user, "sensitive_data_systems", "audit_action") %>
+                  <% if policy(sensitive_data_system).audit_log? %>
                     <li><%= link_to 'Audit', sensitive_data_system_audit_log_path(sensitive_data_system), class: "action-link" %></li>
                   <% end %>
                   </ul>

--- a/app/views/sensitive_data_systems/index.html.erb
+++ b/app/views/sensitive_data_systems/index.html.erb
@@ -163,7 +163,7 @@
 </div>
 
 <div>
-  <% if has_ad_access?(current_user, "sensitive_data_systems", "newedit_action") %>
+  <% if policy(@sensitive_data_systems).edit? %>
     <div class="btn-new btn-blue" role="menu" aria-orientation="vertical" aria-labelledby="mobile-menu-button" tabindex="-1">
       <%= link_to 'New Sensitive Data System', new_sensitive_data_system_path %>
     </div>

--- a/app/views/sensitive_data_systems/show.html.erb
+++ b/app/views/sensitive_data_systems/show.html.erb
@@ -33,13 +33,13 @@
     <span class="flex-grow"></span>
     <span class="ml-4 flex-shrink-0">
       <ul>
-        <% if has_ad_access?(current_user, "sensitive_data_systems", "newedit_action") %>
+        <% if policy(@sensitive_data_system).edit? %>
           <li><%= link_to 'Edit', edit_sensitive_data_system_path(@sensitive_data_system), class: "action-link" %></li>
         <% end %>
-        <% if has_ad_access?(current_user, "sensitive_data_systems", "archive_action") %>
+        <% if policy(@sensitive_data_system).archive? %>
           <li><%= link_to 'Archive', archive_sensitive_data_system_path(@sensitive_data_system), class: "action-link",  method: :post, data: { confirm: 'Are you sure?' } %></li>
         <% end %>
-        <% if has_ad_access?(current_user, "sensitive_data_systems", "audit_action") %>
+        <% if policy(@sensitive_data_system).audit_log? %>
           <li><%= link_to 'Audit', sensitive_data_system_audit_log_path(@sensitive_data_system), class: "action-link" %></li>
         <% end %>
       </ul>

--- a/app/views/tdx_tickets/_tdx_tickets.html.erb
+++ b/app/views/tdx_tickets/_tdx_tickets.html.erb
@@ -12,7 +12,7 @@
               <%= link_to tdx.ticket_link, url_for(tdx.ticket_link) %>
             </span>
           </div>
-          <% if has_ad_access?(current_user, tdx_ticket_resource.class.table_name, "newedit_action") %>
+          <% if policy(tdx_ticket_resource).edit? %>
             <div class="ml-4 flex-shrink-0 flex space-x-4">
               <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                 <%= link_to 'Remove', tdx_ticket_path(tdx.id), method: :delete, data: { confirm: 'Are you sure?' } %>
@@ -31,7 +31,7 @@
       </li>
     <% end %>
   </ul>
-  <% if has_ad_access?(current_user, tdx_ticket_resource.class.table_name, "newedit_action") %>
+  <% if policy(tdx_ticket_resource).edit? %>
     <%= render partial: "tdx_tickets/form", locals: { tdx_ticket_resource: tdx_ticket_resource } %>
   <% end %>
 </dd>


### PR DESCRIPTION
From pundit documentation:
You can easily get a hold of an instance of the policy through the policy method in both the view and controller. This is especially useful for conditionally showing links or buttons in the view:

<% if policy(@post).update? %>
  <%= link_to "Edit post", edit_post_path(@post) %>
<% end %>
------
This allows us to replace our method has_ad_access?(user, table, action=nil) (in application helper) with policy(resource).action? and get rid of that method.

Move set_membership to application_controller to make current_user.membership available in all controllers (including static) if user.sign_in? so policies can be used in the header too. 

Add any_action? method to policies to use it in the header.

Replace has_ad_access? with policy(resource).<action>? in all views to check authorization for buttons.

Th code looks cleaner and nicer now.