### PR TITLE
Fix duo admin dashbord bug

### DIFF
--- a/app/views/layouts/_footer_duo.html.erb
+++ b/app/views/layouts/_footer_duo.html.erb
@@ -1,0 +1,20 @@
+<footer class="grid grid-cols-4 grid-rows-1 gap-0 text-sm text-gray-700 p-4">
+  <div class="col-span-1 justify-self-start">
+  </div>
+  <div class="col-span-2 justify-self-center">
+    <div class="inline-block">
+      <i class="ml-2 inline-block fa fa-phone" aria-hidden="true""></i>
+      <span>734.615.0100</span>
+      <i class="ml-2 inline-block fa fa-envelope" aria-hidden="true""></i>
+      <span><%= mail_to "LSATechnologyServices@umich.edu", "LSATechnologyServices@umich.edu", class: "footer-link" %></span>
+      <i class="ml-2 inline-block fa fa-comments" aria-hidden="true""></i>
+      <span>Report Issue</span>
+    </div>
+  </div>
+  
+  <div class="col-span-4 w-full flex justify-center text-sm pt-2">
+    <div>
+      Copyright <%= Time.now.year %> | <%= link_to 'The Regents of the University of Michigan', 'https://regents.umich.edu', class: "footer-link" %>
+    </div>
+  </div>
+</footer>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="w-full block flex-grow lg:flex lg:items-center lg:w-auto">
       <div class="lg:flex-grow">
-        <% if user_signed_in? %>
+        <% if user_signed_in? && session[:duo_auth] %>
             <%= link_to "Dashboard", dashboard_path, class: "mr-4" %>
             <% if policy(DpaException).any_action? %>
               <%= link_to "DPA Exceptions", dpa_exceptions_path, class: "mr-4" %>

--- a/app/views/layouts/turbo_false_layout.html.erb
+++ b/app/views/layouts/turbo_false_layout.html.erb
@@ -28,6 +28,6 @@
       </turbo-frame>
       <%= yield %>
     </main>
-    <%= render 'layouts/footer' %>
+    <%= render 'layouts/footer_duo' %>
   </body>
 </html>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -352,4 +352,10 @@ ActiveAdmin.setup do |config|
   #
   config.use_webpacker = true
 
+  def check_duo_auth
+    if !session[:duo_auth]
+      redirect_to duo_path
+    end
+  end
+
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -33,6 +33,11 @@ Rails.application.reloader.to_prepare do
     self.responder = Responder
     respond_to :html, :turbo_stream
   end
+
+  ActiveAdmin.setup do |config|
+    config.before_action :check_duo_auth
+  end
+
 end
 
 # Assuming you have not yet modified this file, each configuration option below


### PR DESCRIPTION
The branch was created from the current master branch after 1 pm.
It looks like it doesn't matter in which initializer this code is:

Rails.application.reloader.to_prepare do
 <some things>
end

We have it already in devise.rb, so I added active admin new stuff into it:

ActiveAdmin.setup do |config|
    config.before_action :check_duo_auth
end
