### PR TITLE
Fix duo admin bug without another footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -11,7 +11,7 @@
       <a id="myCustomTrigger" class="footer-link" href="#">Report Issue</a> 
     </div>
   </div>
-  <% if @admin_access %>
+  <% if @admin_access && session[:duo_auth]%>
     <div class="col-span-1 justify-self-end justify-items-end">
       <div class="inline-block">
         <%= link_to 'Admin Dashboard', admin_root_path, class: "footer-link mt-2 pr-4" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="w-full block flex-grow lg:flex lg:items-center lg:w-auto">
       <div class="lg:flex-grow">
-        <% if user_signed_in? %>
+        <% if user_signed_in? && session[:duo_auth] %>
             <%= link_to "Dashboard", dashboard_path, class: "mr-4" %>
             <% if policy(DpaException).any_action? %>
               <%= link_to "DPA Exceptions", dpa_exceptions_path, class: "mr-4" %>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -352,4 +352,10 @@ ActiveAdmin.setup do |config|
   #
   config.use_webpacker = true
 
+  def check_duo_auth
+    if !session[:duo_auth]
+      redirect_to duo_path
+    end
+  end
+
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -33,6 +33,11 @@ Rails.application.reloader.to_prepare do
     self.responder = Responder
     respond_to :html, :turbo_stream
   end
+
+  ActiveAdmin.setup do |config|
+    config.before_action :check_duo_auth
+  end
+  
 end
 
 # Assuming you have not yet modified this file, each configuration option below


### PR DESCRIPTION
Little bit different version of the duo-admin bug fix.

Here Admin Dashboard link in the footer is protected the same way links in the header are protected: by session[:duo_auth].
No need to create another footer file.