### PR TITLE
Fix some things

### DIFF
--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -1,6 +1,6 @@
 class DevicesController < InheritedResources::Base
   before_action :verify_duo_authentication
-  devise_group :logged_in, contains: [:user, :admin_user]
+  devise_group :logged_in, contains: [:user]
   before_action :authenticate_logged_in!
   before_action :set_device, only: [:show, :edit, :update]
   before_action :add_index_breadcrumb, only: [:index, :show, :new, :edit]

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -3,7 +3,7 @@ class DevicesController < InheritedResources::Base
   devise_group :logged_in, contains: [:user]
   before_action :authenticate_logged_in!
   before_action :set_device, only: [:show, :edit, :update]
-  before_action :add_index_breadcrumb, only: [:index, :show, :new, :edit]
+  before_action :add_index_breadcrumb, only: [:index, :show]
 
   def index
     @device_index_text = Infotext.find_by(location: "device_index")
@@ -20,14 +20,12 @@ class DevicesController < InheritedResources::Base
   end
 
   def edit
-    add_breadcrumb(@device.display_name, device_path(@device))
-    add_breadcrumb('Edit')
     authorize @device
   end
 
   def new
     @device = Device.new
-    add_breadcrumb('New')
+    authorize @device
   end
 
   def create

--- a/app/controllers/dpa_exceptions_controller.rb
+++ b/app/controllers/dpa_exceptions_controller.rb
@@ -1,6 +1,6 @@
 class DpaExceptionsController < InheritedResources::Base
   before_action :verify_duo_authentication
-  devise_group :logged_in, contains: [:user, :admin_user]
+  devise_group :logged_in, contains: [:user]
   before_action :authenticate_logged_in!
   before_action :set_dpa_exception, only: [:show, :edit, :update, :archive, :unarchive, :audit_log]
   before_action :add_index_breadcrumb, only: [:index, :show, :new, :edit, :audit_log]

--- a/app/controllers/it_security_incidents_controller.rb
+++ b/app/controllers/it_security_incidents_controller.rb
@@ -1,6 +1,6 @@
 class ItSecurityIncidentsController < InheritedResources::Base
   before_action :verify_duo_authentication
-  devise_group :logged_in, contains: [:user, :admin_user]
+  devise_group :logged_in, contains: [:user]
   before_action :authenticate_logged_in!
   before_action :set_it_security_incident, only: [:show, :edit, :update, :archive, :unarchive, :audit_log]
   before_action :add_index_breadcrumb, only: [:index, :show, :new, :edit, :audit_log]

--- a/app/controllers/legacy_os_records_controller.rb
+++ b/app/controllers/legacy_os_records_controller.rb
@@ -73,8 +73,10 @@ class LegacyOsRecordsController < InheritedResources::Base
       @note ||= device_class.message || ""
       @note = "" if device_class.device_exist?
     else
-      flash.now[:alert] = device_class.message
-      render turbo_stream: turbo_stream.update("flash", partial: "layouts/notification")
+      # TDX search returns too many results for entered serial or hostname
+      @legacy_os_record.errors.add(:device, device_class.message)
+      @legacy_os_record.device = Device.new(legacy_os_record_params[:device_attributes])
+      render :new
       return
     end
 
@@ -115,13 +117,16 @@ class LegacyOsRecordsController < InheritedResources::Base
       if device.save
         @legacy_os_record.device_id = device.id
       else
-        flash.now[:alert] = "Error saving device"
-        render turbo_stream: turbo_stream.update("flash", partial: "layouts/notification")
+        @legacy_os_record.errors.add(:device, "Error saving device")
+        @legacy_os_record.device = Device.new(legacy_os_record_params[:device_attributes])
+        render :edit
         return
       end
     else
-      flash.now[:alert] = device_class.message
-      render turbo_stream: turbo_stream.update("flash", partial: "layouts/notification")
+      # TDX search returns too many results for entered serial or hostname
+      @legacy_os_record.errors.add(:device, device_class.message)
+      @legacy_os_record.device = Device.new(legacy_os_record_params[:device_attributes])
+      render :edit
       return
     end
 

--- a/app/controllers/legacy_os_records_controller.rb
+++ b/app/controllers/legacy_os_records_controller.rb
@@ -1,6 +1,6 @@
 class LegacyOsRecordsController < InheritedResources::Base
   before_action :verify_duo_authentication
-  devise_group :logged_in, contains: [:user, :admin_user]
+  devise_group :logged_in, contains: [:user]
   before_action :authenticate_logged_in!
   before_action :set_legacy_os_record, only: [:show, :edit, :update, :archive, :unarchive, :audit_log]
   before_action :get_access_token, only: [:create, :update]

--- a/app/controllers/sensitive_data_systems_controller.rb
+++ b/app/controllers/sensitive_data_systems_controller.rb
@@ -65,7 +65,6 @@ class SensitiveDataSystemsController < InheritedResources::Base
     if sensitive_data_system_params[:tdx_ticket][:ticket_link].present?
       @sensitive_data_system.tdx_tickets.new(ticket_link: sensitive_data_system_params[:tdx_ticket][:ticket_link])
     end
-    @note = ""
     serial = sensitive_data_system_params[:device_attributes][:serial]
     hostname = sensitive_data_system_params[:device_attributes][:hostname]
     if serial.present? || hostname.present?
@@ -73,6 +72,7 @@ class SensitiveDataSystemsController < InheritedResources::Base
       if device_class.create_device || device_class.device_exist?
         @sensitive_data_system.device = device_class.device
         @note ||= device_class.message || ""
+        @note = "" if device_class.device_exist?
       else
         # TDX search returns too many results for entered serial or hostname
         @sensitive_data_system.errors.add(:device, device_class.message)
@@ -106,13 +106,13 @@ class SensitiveDataSystemsController < InheritedResources::Base
     if sensitive_data_system_params[:tdx_ticket][:ticket_link].present?
       @sensitive_data_system.tdx_tickets.create(ticket_link: sensitive_data_system_params[:tdx_ticket][:ticket_link])
     end
-    @note = ""
     if sensitive_data_system_params[:storage_location_id].present? && StorageLocation.find(sensitive_data_system_params[:storage_location_id]).device_is_required
       serial = sensitive_data_system_params[:device_attributes][:serial]
       hostname = sensitive_data_system_params[:device_attributes][:hostname]
       device_class = DeviceManagment.new(serial, hostname)
       if device_class.device_exist?
         @sensitive_data_system.device_id = device_class.device.id
+        @note = ""
       elsif device_class.create_device
         # need to save device
         device = device_class.device

--- a/app/controllers/sensitive_data_systems_controller.rb
+++ b/app/controllers/sensitive_data_systems_controller.rb
@@ -74,8 +74,10 @@ class SensitiveDataSystemsController < InheritedResources::Base
         @sensitive_data_system.device = device_class.device
         @note ||= device_class.message || ""
       else
-        flash.now[:alert] = device_class.message
-        render turbo_stream: turbo_stream.update("flash", partial: "layouts/notification")
+        # TDX search returns too many results for entered serial or hostname
+        @sensitive_data_system.errors.add(:device, device_class.message)
+        @sensitive_data_system.device = Device.new(sensitive_data_system_params[:device_attributes])
+        render :new
         return
       end
     end
@@ -118,13 +120,16 @@ class SensitiveDataSystemsController < InheritedResources::Base
         if device.save
           @sensitive_data_system.device_id = device.id
         else
-          flash.now[:alert] = "Error saving device"
-          render turbo_stream: turbo_stream.update("flash", partial: "layouts/notification")
+          @sensitive_data_system.errors.add(:device, "Error saving device")
+          @sensitive_data_system.device = Device.new(sensitive_data_system_params[:device_attributes])
+          render :edit
           return
         end
       else
-        flash.now[:alert] = device_class.message
-        render turbo_stream: turbo_stream.update("flash", partial: "layouts/notification")
+        # TDX search returns too many results for entered serial or hostname
+        @sensitive_data_system.errors.add(:device, device_class.message)
+        @sensitive_data_system.device = Device.new(sensitive_data_system_params[:device_attributes])
+        render :edit
         return
       end
     else

--- a/app/controllers/sensitive_data_systems_controller.rb
+++ b/app/controllers/sensitive_data_systems_controller.rb
@@ -1,6 +1,6 @@
 class SensitiveDataSystemsController < InheritedResources::Base
   before_action :verify_duo_authentication
-  devise_group :logged_in, contains: [:user, :admin_user]
+  devise_group :logged_in, contains: [:user]
   before_action :authenticate_logged_in!
   before_action :set_sensitive_data_system, only: [:show, :edit, :update, :archive, :unarchive, :audit_log]
   before_action :get_access_token, only: [:create, :update]

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -7,7 +7,6 @@ class StaticPagesController < ApplicationController
   end
 
   def dashboard
-    @current_username = current_user.nil? ? current_admin_user.username : current_user.username
     @dashboard_text = Infotext.find_by(location: "dashboard")
     add_breadcrumb(action_name.titleize)
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -39,7 +39,6 @@ class Users::SessionsController < Devise::SessionsController
           membership.append(g.first.remove("CN="))
         end
         session[:user_memberships] = membership
-        # logger.debug "*********** session[:user_memberships] ***** #{session[:user_memberships]}"
       end
     end
 end

--- a/app/helpers/infotext_helper.rb
+++ b/app/helpers/infotext_helper.rb
@@ -1,2 +1,0 @@
-module InfotextHelper
-end

--- a/app/models/data_classification_level.rb
+++ b/app/models/data_classification_level.rb
@@ -9,6 +9,9 @@
 #  updated_at  :datetime         not null
 #
 class DataClassificationLevel < ApplicationRecord
-    has_many :data_types
-    audited
+  has_many :data_types
+  audited
+
+  validates :name, uniqueness: true
+  
 end

--- a/app/models/data_type.rb
+++ b/app/models/data_type.rb
@@ -18,6 +18,8 @@ class DataType < ApplicationRecord
   has_many :sensitive_data_systems
   audited
 
+  validates :name, uniqueness: true
+
   def display_name
     "#{self.name} - #{DataClassificationLevel.find(data_classification_level_id).name}"
   end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -10,9 +10,11 @@
 #  updated_at       :datetime         not null
 #
 class Department < ApplicationRecord
-    has_many :legacy_os_records
-    has_many :sensitive_data_systems
-    has_many :dpa_exceptions
+  has_many :legacy_os_records
+  has_many :sensitive_data_systems
+  has_many :dpa_exceptions
+
+  validates :name, :shortname, uniqueness: true
 
   def display_name
     "#{self.name}"

--- a/app/models/dpa_exception_status.rb
+++ b/app/models/dpa_exception_status.rb
@@ -12,6 +12,8 @@ class DpaExceptionStatus < ApplicationRecord
 
   has_many :dpa_exception
 
+  validates :name, uniqueness: true
+  
   def display_name
     "#{self.name}"
   end

--- a/app/models/it_security_incident_status.rb
+++ b/app/models/it_security_incident_status.rb
@@ -10,4 +10,7 @@
 #
 class ItSecurityIncidentStatus < ApplicationRecord
   has_many :it_security_incident
+
+  validates :name, uniqueness: true
+  
 end

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -11,15 +11,17 @@
 #  device_is_required :boolean          default(FALSE)
 #
 class StorageLocation < ApplicationRecord
-    has_many :sensitive_data_systems
-    audited
+  has_many :sensitive_data_systems
+  audited
 
-    def display_name
-        if self.device_is_required
-          "#{self.name} - device is required"
-        else
-          "#{self.name}"
-        end
-      end
-      
+  validates :name, uniqueness: true
+
+  def display_name
+    if self.device_is_required
+      "#{self.name} - device is required"
+    else
+      "#{self.name}"
+    end
+  end
+
 end

--- a/app/policies/device_policy.rb
+++ b/app/policies/device_policy.rb
@@ -17,8 +17,7 @@ class DevicePolicy < ApplicationPolicy
     end  
 
     def new?
-      get_ldap_groups('devices', 'newedit')
-      (user.membership & @ldap_groups).any?
+      false
     end
 
     def archive?
@@ -37,8 +36,7 @@ class DevicePolicy < ApplicationPolicy
     end
 
     def destroy?
-      get_ldap_groups('devices', 'archive')
-      (user.membership & @ldap_groups).any?
+      false
     end
 
   end

--- a/app/views/legacy_os_records/_form.html.erb
+++ b/app/views/legacy_os_records/_form.html.erb
@@ -215,7 +215,7 @@
             <div class="w-1/3 pr-4">
               <%= form.label :serial %>
               <%= device_attributes.text_field :serial, :"data-legacyos-target" => "serial" %>
-              <span class="device-error--hide" data-legacyos-target="serial_error">
+              <span class="device-error--hide text-red-500" data-legacyos-target="serial_error">
                 Add serial number
               </span>
               <p class="help-text"></p>
@@ -224,7 +224,7 @@
             <div class="w-1/3">
               <%= form.label :hostname %>
               <%= device_attributes.text_field :hostname, :"data-legacyos-target" => "hostname" %>
-              <span class="device-error--hide" data-legacyos-target="hostname_error">
+              <span class="device-error--hide text-red-500" data-legacyos-target="hostname_error">
                 or hostname
               </span>
               <p class="help-text"></p>

--- a/app/views/legacy_os_records/_form.html.erb
+++ b/app/views/legacy_os_records/_form.html.erb
@@ -215,7 +215,7 @@
             <div class="w-1/3 pr-4">
               <%= form.label :serial %>
               <%= device_attributes.text_field :serial, :"data-legacyos-target" => "serial" %>
-              <span class="device-error--hide text-red-500" data-legacyos-target="serial_error">
+              <span class="device-error--hide text-red-700" data-legacyos-target="serial_error">
                 Add serial number
               </span>
               <p class="help-text"></p>
@@ -224,7 +224,7 @@
             <div class="w-1/3">
               <%= form.label :hostname %>
               <%= device_attributes.text_field :hostname, :"data-legacyos-target" => "hostname" %>
-              <span class="device-error--hide text-red-500" data-legacyos-target="hostname_error">
+              <span class="device-error--hide text-red-700" data-legacyos-target="hostname_error">
                 or hostname
               </span>
               <p class="help-text"></p>

--- a/app/views/sensitive_data_systems/_form.html.erb
+++ b/app/views/sensitive_data_systems/_form.html.erb
@@ -131,7 +131,7 @@
           <div class="w-1/3 pr-4">
             <%= form.label :serial %>
             <%= device_attributes.text_field :serial, :"data-sensitiveds-target" => "serial" %>
-            <span class="device-error--hide text-red-500" data-sensitiveds-target="serial_error">
+            <span class="device-error--hide text-red-700" data-sensitiveds-target="serial_error">
               Add serial number
             </span>
             <p class="help-text">Help text if needed</p>
@@ -140,7 +140,7 @@
           <div class="w-1/3">
             <%= form.label :hostname %>
             <%= device_attributes.text_field :hostname, :"data-sensitiveds-target" => "hostname" %>
-            <span class="device-error--hide text-red-500" data-sensitiveds-target="hostname_error">
+            <span class="device-error--hide text-red-700" data-sensitiveds-target="hostname_error">
               or hostname
             </span>
             <p class="help-text">Help text if needed</p>

--- a/app/views/sensitive_data_systems/_form.html.erb
+++ b/app/views/sensitive_data_systems/_form.html.erb
@@ -131,7 +131,7 @@
           <div class="w-1/3 pr-4">
             <%= form.label :serial %>
             <%= device_attributes.text_field :serial, :"data-sensitiveds-target" => "serial" %>
-            <span class="device-error--hide" data-sensitiveds-target="serial_error">
+            <span class="device-error--hide text-red-500" data-sensitiveds-target="serial_error">
               Add serial number
             </span>
             <p class="help-text">Help text if needed</p>
@@ -140,7 +140,7 @@
           <div class="w-1/3">
             <%= form.label :hostname %>
             <%= device_attributes.text_field :hostname, :"data-sensitiveds-target" => "hostname" %>
-            <span class="device-error--hide" data-sensitiveds-target="hostname_error">
+            <span class="device-error--hide text-red-500" data-sensitiveds-target="hostname_error">
               or hostname
             </span>
             <p class="help-text">Help text if needed</p>


### PR DESCRIPTION
Remove all mentions of admin_user
Add [validate uniqueness] to all complementary tables
Make authorization for device's new and destroy methods false
Remove comments, an unneeded file and fix some formats

LegacyOsRecords & SensitiveDataSystems: 

- make device validation text red
- replace turbo_stream (that flashes device_class's messages) with render (because _form.html.erb is now [turbo: "false"]), and add these messages to <object>.errors
Replace this:
```
flash.now[:alert] = device_class.message
render turbo_stream: turbo_stream.update("flash", partial: "layouts/notification")
```
with this:
```
@legacy_os_record.errors.add(:device, device_class.message)
render :new
```
