### PR TITLE
Set timeout to 8 hours

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -252,7 +252,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 55.minutes
+  config.timeout_in = 480.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
I tested the current timeout setting on the production server - it's 55 minutes.
I changed the setting on my localhost to 480 minutes and tested it. I logged in just before midnight and my session was not expired at 6:30 in the morning.
I guess it works correctly.