### PR TITLE
Lra 176 remove sla agreements

### DIFF
--- a/app/admin/dpa_exceptions.rb
+++ b/app/admin/dpa_exceptions.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register DpaException do
   #
   # Uncomment all parameters which should be permitted for assignment
   #
-  permit_params :review_date_exception_first_approval_date, :third_party_product_service, :department_id, :point_of_contact, :review_findings, :review_summary, :lsa_security_recommendation, :lsa_security_determination, :lsa_security_approval, :lsa_technology_services_approval, :exception_approval_date_exception_renewal_date_due, :notes, :sla_agreement, :data_type_id, :incomplete, :review_date_exception_review_date, :dpa_exception_status_id, :deleted_at
+  permit_params :review_date_exception_first_approval_date, :third_party_product_service, :department_id, :point_of_contact, :review_findings, :review_summary, :lsa_security_recommendation, :lsa_security_determination, :lsa_security_approval, :lsa_technology_services_approval, :exception_approval_date_exception_renewal_date_due, :notes, :data_type_id, :incomplete, :review_date_exception_review_date, :dpa_exception_status_id, :deleted_at
   #
   # or
   #
@@ -73,13 +73,6 @@ ActiveAdmin.register DpaException do
       row :exception_approval_date_exception_renewal_date_due
       row :review_date_exception_review_date
       row :notes
-      row :sla_agreement
-      row :sla_attachment do |sla|
-        if sla.sla_attachment.attached?
-            sla.sla_attachment.filename
-            link_to sla.sla_attachment.filename, url_for(sla.sla_attachment)
-        end
-      end
       row :data_type.name
     end
     panel "Attachments" do 

--- a/app/controllers/dpa_exceptions_controller.rb
+++ b/app/controllers/dpa_exceptions_controller.rb
@@ -59,11 +59,7 @@ class DpaExceptionsController < InheritedResources::Base
         partial: "dpa_exceptions/listing"
       )
       end
-
     end
-
-
-    
   end
 
   def show

--- a/app/controllers/dpa_exceptions_controller.rb
+++ b/app/controllers/dpa_exceptions_controller.rb
@@ -198,8 +198,8 @@ class DpaExceptionsController < InheritedResources::Base
                     :lsa_security_recommendation, :lsa_security_determination, 
                     :lsa_security_approval, :lsa_technology_services_approval, 
                     :exception_approval_date_exception_renewal_date_due, 
-                    :review_date_exception_review_date, :notes, :sla_agreement,
-                    :sla_attachment, :data_type_id, :incomplete, :m,
+                    :review_date_exception_review_date, :notes,
+                    :data_type_id, :incomplete, :m,
                     :dpa_exception_status_id, :format,
                     attachments: [], tdx_ticket: [:ticket_link]
                   )

--- a/app/models/dpa_exception.rb
+++ b/app/models/dpa_exception.rb
@@ -35,7 +35,6 @@ class DpaException < ApplicationRecord
   has_rich_text :lsa_security_determination
   has_one :lsa_security_determination, class_name: 'ActionText::RichText', as: :record
   has_many_attached :attachments
-  has_one_attached :sla_attachment
   before_save :if_not_complete
 
   audited
@@ -44,7 +43,6 @@ class DpaException < ApplicationRecord
             :department_id, presence: true
   validates :dpa_exception_status_id, presence: true
   validate :acceptable_attachments
-  validate :acceptable_sla_attachment
 
   scope :active, -> { where(deleted_at: nil) }
   scope :archived, -> { where("#{self.table_name}.deleted_at IS NOT NULL") }
@@ -85,29 +83,6 @@ class DpaException < ApplicationRecord
     end
   end
 
-  def acceptable_sla_attachment
-    return unless sla_attachment.attached?
-  
-    acceptable_types = [
-      "application/pdf", "text/plain" "image/jpg", 
-      "image/jpeg", "image/png", 
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      "application/vnd.apple.pages",
-      "application/vnd.apple.numbers",
-      "application/x-tar"
-    ]
-
-    unless sla_attachment.byte_size <= 20.megabyte
-      errors.add(:sla_attachment, "is too big")
-    end
-
-    unless acceptable_types.include?(sla_attachment.content_type)
-      errors.add(:sla_attachment, "must be an acceptable file type")
-    end
-
-  end
-
   def if_not_complete
     if self.not_completed?
       self.incomplete = true
@@ -124,11 +99,11 @@ class DpaException < ApplicationRecord
     fields = %w{id incomplete dpa_exception_status_id review_date_exception_first_approval_date third_party_product_service
               department_id point_of_contact review_findings review_summary lsa_security_recommendation lsa_security_determination
               lsa_security_approval lsa_technology_services_approval exception_approval_date_exception_renewal_date_due notes
-              sla_agreement data_type_id review_date_exception_review_date}
+              data_type_id review_date_exception_review_date}
     header = %w{link incomplete dpa_exception_status review_date_exception_first_approval_date third_party_product_service
               department_used_by point_of_contact review_findings review_summary lsa_security_recommendation lsa_security_determination
               lsa_security_approval lsa_technology_services_approval exception_approval_date_exception_renewal_date_due notes
-              sla_agreement data_type review_date_exception_review_date}
+              data_type review_date_exception_review_date}
     header.map! { |e| e.titleize.upcase }
     key_id = 'id'
     CSV.generate(headers: true) do |csv|

--- a/app/views/dpa_exceptions/_dpa_exception.json.jbuilder
+++ b/app/views/dpa_exceptions/_dpa_exception.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! dpa_exception, :id, :review_date, :third_party_product_service, :department_id, :point_of_contact, :review_findings, :review_summary, :lsa_security_recommendation, :lsa_security_determination, :lsa_security_approval, :lsa_technology_services_approval, :exception_approval_date, :notes, :tdx_ticket, :sla_agreement, :data_type_id, :created_at, :updated_at
+json.extract! dpa_exception, :id, :review_date, :third_party_product_service, :department_id, :point_of_contact, :review_findings, :review_summary, :lsa_security_recommendation, :lsa_security_determination, :lsa_security_approval, :lsa_technology_services_approval, :exception_approval_date, :notes, :tdx_ticket, :data_type_id, :created_at, :updated_at
 json.url dpa_exception_url(dpa_exception, format: :json)

--- a/app/views/dpa_exceptions/_form.html.erb
+++ b/app/views/dpa_exceptions/_form.html.erb
@@ -170,37 +170,6 @@
         <% end %>
       </div>
 
-      <div id="sla_agreement_file" class="field">
-        <%= form.label :sla_agreement, "SLA Agreement" %>
-        <%= form.text_field :sla_agreement %>
-        <p class="help-text"></p>
-      </div>
-
-      <div class="field">
-        <%= form.label :sla_attachment, "SLA Agreement File" %>
-        <%= form.file_field :sla_attachment %>
-        <p class="help-text">Selecting a file will replace the currently attached file!</p>
-        <% if @dpa_exception.sla_attachment.attached? %>
-          <div class="py-4 pl-4 sm:grid sm:py-5 sm:grid-cols-3 sm:gap-4">
-            <dt class="text-sm font-medium text-gray-500">
-              SLA Agreement currently connected to this record: 
-            </dt>
-            <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-              <ul class="border border-gray-200 rounded-md divide-y divide-gray-200">
-                <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-                  <div class="w-0 flex-1 flex items-center">
-                    <i class="fas fa-paperclip text-gray-400"></i>
-                    <span class="ml-2 flex-1 w-0 truncate">
-                      <%= link_to @dpa_exception.sla_attachment.filename, url_for(@dpa_exception.sla_attachment), target: "_blank" %>
-                    </span>
-                  </div>
-                </li>
-              </ul>
-            </dd>
-          </div>
-        <% end %>
-      </div>
-
       <div id="attached_files" class="field">
         <%= form.label :attachments, "Attachments (pdf,txt,jpg,png,doc,xls)" %>
         <%= form.file_field :attachments, multiple: true %>

--- a/app/views/dpa_exceptions/show.html.erb
+++ b/app/views/dpa_exceptions/show.html.erb
@@ -147,59 +147,6 @@
   </div>
 
   <div class="py-4 sm:grid sm:py-5 sm:grid-cols-3 sm:gap-4">
-    <dt class="text-sm font-medium text-gray-500">
-      SLA Agreement 
-    </dt>
-    <dd class="mt-1 flex text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-      <span class="flex-grow"><%= @dpa_exception.sla_agreement %></span>
-    </dd>
-  </div>
-
-  <div class="py-4 sm:grid sm:py-5 sm:grid-cols-3 sm:gap-4">
-    <dt class="text-sm font-medium text-gray-500">
-      SLA Agreement Uploaded File
-    </dt>
-    <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-      <ul class="border border-gray-200 rounded-md divide-y divide-gray-200">
-        <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-          <% if @dpa_exception.sla_attachment.attached? %>
-            <div class="w-0 flex-1 flex items-center">
-              <i class="fas fa-paperclip text-gray-400"></i>
-              <span class="ml-2 flex-1 w-0 truncate">
-                <%= link_to @dpa_exception.sla_attachment.filename, url_for(@dpa_exception.sla_attachment), target: "_blank" %>
-              </span>
-            </div>
-            <% if policy(@dpa_exception).edit? %>
-              <div class="ml-4 flex-shrink-0 flex space-x-4">
-                <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                  <%= link_to 'Update', edit_dpa_exception_path(@dpa_exception, anchor: "sla_agreement_file") %>
-                </button>
-                <span class="text-gray-300" aria-hidden="true">|</span>
-                <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                  <%= link_to 'Remove', delete_file_path(@dpa_exception.sla_attachment.id), data: { confirm: "Are sure you?"} %>
-                </button>
-              </div>
-            <% end %>
-          <% else %>
-            <div class="w-0 flex-1 flex items-center">
-              <span class="ml-2 flex-1 w-0 truncate">
-                you currently do not have an SLA Agreement attached.
-              </span>
-            </div>
-            <% if policy(@dpa_exception).edit? %>
-              <div class="ml-4 flex-shrink-0 flex space-x-4">
-                <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                  <%= link_to 'Add', edit_dpa_exception_path(@dpa_exception) %>
-                </button>
-              </div>
-            <% end %>
-          <% end %>
-        </li>
-      </ul>
-    </dd>
-  </div>
-
-  <div class="py-4 sm:grid sm:py-5 sm:grid-cols-3 sm:gap-4">
     <%= render partial: "partials/show_attachments", locals: { attached_files_resource: @dpa_exception } %>
   </div>
 </dl>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
   end
 
   get 'dpa_exceptions/audit_log/:id', to: 'dpa_exceptions#audit_log', as: :dpa_exception_audit_log
-  get 'dpa_exceptions/delete_file_attachment/:id', to: 'dpa_exceptions#delete_file_attachment', as: :delete_sla_agreement
+  # get 'dpa_exceptions/delete_file_attachment/:id', to: 'dpa_exceptions#delete_file_attachment', as: :delete_sla_agreement
   resources :dpa_exceptions do
     resources :tdx_tickets, module: :dpa_exceptions
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,6 @@ Rails.application.routes.draw do
   end
 
   get 'dpa_exceptions/audit_log/:id', to: 'dpa_exceptions#audit_log', as: :dpa_exception_audit_log
-  # get 'dpa_exceptions/delete_file_attachment/:id', to: 'dpa_exceptions#delete_file_attachment', as: :delete_sla_agreement
   resources :dpa_exceptions do
     resources :tdx_tickets, module: :dpa_exceptions
   end


### PR DESCRIPTION
I removed sla_agreement and sla attachment from views, CSV export, and active admin.
I removed sla attachment from the model but left the sla_agreement field in the model.