### PR TITLE
Lra 180 add another validation to access lookup

### DIFF
--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -58,7 +58,7 @@ class DevicesController < InheritedResources::Base
     if device_class.update_device
       note ||= device_class.message || ""
       if @device.update(device_class.device_attr)
-        redirect_to @device, notice: 'Device record was successfully updated.' + note
+        redirect_to @device, notice: 'Device record was successfully updated. ' + note
       else
         format.turbo_stream
       end

--- a/app/models/access_lookup.rb
+++ b/app/models/access_lookup.rb
@@ -30,7 +30,10 @@ class AccessLookup < ApplicationRecord
   }, _prefix: true
 
   validates :ldap_group, presence: true
-  validates :vod_table, presence: true
   validates :vod_action, presence: true
+  validate :select_vod_table
 
+  def select_vod_table
+    errors.add(:vod_table, "select a table") if vod_table == "not_selected"
+  end
 end


### PR DESCRIPTION
By default vod_table has "not_selected" value. This is why presence validation was useless.
I replaced it with another one that checks if something else then "not_selected" is selected.