### PR TITLE
remove rememberable module

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
   attr_accessor :membership, :dept_membership
 
   # Include default devise modules. Others available are:
-  devise :ldap_authenticatable, :rememberable, :trackable, :timeoutable,
+  devise :ldap_authenticatable, :trackable, :timeoutable,
          :lockable
 
   scope :recent, -> { where("current_sign_in_at > ?", 2.days.ago) }


### PR DESCRIPTION
The rememberable module allows for a token to be set to allow by-passing a prompt for credentials if a user successfully signs-on. In our system we use DUO which is managing the users authentication and the rememberable token will not be set and the DUO authentication system does not support the use of  this functionality within the devise library