### PR TITLE
Add custom failure app to manage LDAP issues

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,9 +11,18 @@ class Users::SessionsController < Devise::SessionsController
    end
 
   # POST /resource/sign_in
-   def create
-     super
-   end
+  def create
+    if params[:user][:username].blank? || params[:user][:password].blank?
+      flash[:alert] = "Username and password can't be blank."
+      redirect_to new_user_session_path and return
+    end
+    super
+  rescue DeviseLdapAuthenticatable::LdapException => e
+    # Log the error and redirect
+    Rails.logger.error "LDAP Error: #{e.message}"
+    flash[:alert] = "Authentication failed. Please check your credentials."
+    redirect_to new_user_session_path
+  end
 
   # DELETE /resource/sign_out
    def destroy

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -16,6 +16,7 @@ Devise.setup do |config|
 
   # ==> Warden configuration
   config.warden do |manager|
+    manager.failure_app = CustomFailureApp
   end
 
   # ==> LDAP Configuration

--- a/lib/custom_failure_app.rb
+++ b/lib/custom_failure_app.rb
@@ -1,0 +1,26 @@
+class CustomFailureApp < Devise::FailureApp
+  def respond
+    if ldap_not_authenticated?
+      redirect_to ldap_error_path
+    elsif request.format == :turbo_stream
+      redirect
+    else
+      super
+    end
+  end
+
+  protected
+
+  def redirect
+    message = i18n_message(:invalid)
+    flash[:alert] = message
+    redirect_to new_user_session_path
+  end
+
+  private
+
+  def ldap_not_authenticated?
+    # Check the environment or specific error codes/messages to identify the LDAP issue
+    request.env['warden'].message == :ldap_not_authenticated
+  end
+end


### PR DESCRIPTION
This pull request adds a custom failure app to handle LDAP authentication issues. It includes checks for empty username or password and returns appropriate error messages. Additionally, it includes a new class `CustomFailureApp` that redirects users to the login page with an error message when LDAP authentication fails.