### PR TITLE
Refactor rich text handling in CSV export methods

### DIFF
--- a/app/models/dpa_exception.rb
+++ b/app/models/dpa_exception.rb
@@ -129,7 +129,7 @@ class DpaException < ApplicationRecord
         fields.each do |field|
           value = case field
           when 'id'
-            "http://localhost:3000/dpa_exceptions/#{record.id}"
+            record.id
           when 'data_type_id'
             record.data_type&.display_name
           when 'department_id'

--- a/app/models/dpa_exception.rb
+++ b/app/models/dpa_exception.rb
@@ -137,7 +137,8 @@ class DpaException < ApplicationRecord
           when 'dpa_exception_status_id'
             record.dpa_exception_status&.name
           when 'review_findings', 'review_summary', 'lsa_security_recommendation', 'lsa_security_determination', 'notes'
-            record.send(field)&.to_plain_text
+            rich_text = record.send(field)
+            rich_text.present? ? rich_text.to_plain_text : ''
           when 'tdx_tickets'
             record.tdx_tickets.map(&:ticket_link).join("; ")
           else

--- a/app/models/dpa_exception.rb
+++ b/app/models/dpa_exception.rb
@@ -109,49 +109,7 @@ class DpaException < ApplicationRecord
     not_completed = self.attributes.except("id", "created_at", "updated_at", "deleted_at", "incomplete", "notes", "sla_agreement").all? {|k, v| v.present?} ? false : true
   end
 
-  def self.to_csv
-    fields = %w{id incomplete dpa_exception_status_id review_date_exception_first_approval_date third_party_product_service
-              department_id point_of_contact review_findings review_summary lsa_security_recommendation lsa_security_determination
-              lsa_security_approval lsa_technology_services_approval exception_approval_date_exception_renewal_date_due notes
-              data_type_id review_date_exception_review_date tdx_tickets}
-
-    header = %w{link incomplete dpa_exception_status review_date_exception_first_approval_date third_party_product_service
-              department_used_by point_of_contact review_findings review_summary lsa_security_recommendation lsa_security_determination
-              lsa_security_approval lsa_technology_services_approval exception_approval_date_exception_renewal_date_due notes
-              data_type review_date_exception_review_date tdx_tickets}
-
-    header.map! { |e| e.titleize.upcase }
-
-    CSV.generate(headers: true) do |csv|
-      csv << header
-      all.each do |record|
-        row = []
-        fields.each do |field|
-          value = case field
-          when 'id'
-            record.id
-          when 'data_type_id'
-            record.data_type&.display_name
-          when 'department_id'
-            record.department&.name
-          when 'dpa_exception_status_id'
-            record.dpa_exception_status&.name
-          when 'review_findings', 'review_summary', 'lsa_security_recommendation', 'lsa_security_determination', 'notes'
-            rich_text = record.send(field)
-            rich_text.present? ? rich_text.to_plain_text : ''
-          when 'tdx_tickets'
-            record.tdx_tickets.map(&:ticket_link).join("; ")
-          else
-            record.send(field)
-          end
-          row << value
-        end
-        csv << row
-      end
-    end
-  end
-
-  def display_name
+    def display_name
     "#{self.third_party_product_service}"
   end
 
@@ -161,6 +119,75 @@ class DpaException < ApplicationRecord
     if review_date_exception_review_date.to_date <= review_date_exception_first_approval_date.to_date
       errors.add(:review_date_exception_review_date, "must be after the first approval date")
     end
+  end
+
+  def self.to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << csv_headers
+      csv_records.each { |record| csv << build_row(record) }
+    end
+  end
+
+  private
+
+  def self.csv_fields
+    %w[
+      id incomplete dpa_exception_status_id review_date_exception_first_approval_date
+      third_party_product_service department_id point_of_contact review_findings
+      review_summary lsa_security_recommendation lsa_security_determination
+      lsa_security_approval lsa_technology_services_approval
+      exception_approval_date_exception_renewal_date_due notes data_type_id
+      review_date_exception_review_date tdx_tickets
+    ]
+  end
+
+  def self.csv_headers
+    %w[
+      link incomplete dpa_exception_status review_date_exception_first_approval_date
+      third_party_product_service department_used_by point_of_contact review_findings
+      review_summary lsa_security_recommendation lsa_security_determination
+      lsa_security_approval lsa_technology_services_approval
+      exception_approval_date_exception_renewal_date_due notes data_type
+      review_date_exception_review_date tdx_tickets
+    ].map(&:titleize).map(&:upcase)
+  end
+
+  def self.csv_records
+    includes(:data_type, :department, :dpa_exception_status, :tdx_tickets,
+            :review_findings, :review_summary, :lsa_security_recommendation,
+            :lsa_security_determination, :notes)
+  end
+
+  def self.build_row(record)
+    csv_fields.each_with_object([]) do |field, row|
+      row << format_field(record, field)
+    end
+  end
+
+  def self.format_field(record, field)
+    case field
+    when 'id'
+      generate_url(record)
+    when 'data_type_id'
+      record.data_type&.display_name
+    when 'department_id'
+      record.department&.name
+    when 'dpa_exception_status_id'
+      record.dpa_exception_status&.name
+    when 'review_findings', 'review_summary', 'lsa_security_recommendation', 'lsa_security_determination', 'notes'
+      record.send(field)&.to_plain_text || ''
+    when 'tdx_tickets'
+      record.tdx_tickets.map(&:ticket_link).join('; ')
+    else
+      record.attributes[field]
+    end
+  end
+
+  def self.generate_url(record)
+    Rails.application.routes.url_helpers.dpa_exception_url(
+      record,
+      host: Rails.application.config.action_mailer.default_url_options[:host]
+    )
   end
 
 end

--- a/app/models/it_security_incident.rb
+++ b/app/models/it_security_incident.rb
@@ -101,48 +101,68 @@ class ItSecurityIncident < ApplicationRecord
     self.attributes.except("id", "created_at", "updated_at", "deleted_at", "incomplete", "notes").all? {|k, v| v.present?} ? false : true
   end
 
-  # require 'nokogiri'
+  def display_name
+    "#{self.title} - #{self.id}"
+  end
 
   def self.to_csv
-    fields = %w{id incomplete title date people_involved equipment_involved remediation_steps
-              estimated_financial_cost notes it_security_incident_status_id data_type_id tdx_tickets}
-    header = %w{link incomplete title date people_involved equipment_involved remediation_steps
-              estimated_financial_cost notes it_security_incident_status data_type tdx_tickets}
-    header.map! { |e| e.titleize.upcase }
-    key_id = 'id'
     CSV.generate(headers: true) do |csv|
-      csv << header
-      all.each do |a|
-        row = []
-        record_id = a.attributes.values_at(key_id)[0]
-        fields.each do |key|
-          if key == 'id'
-            row << "http://localhost:3000/it_security_incidents/" + a.attributes.values_at(key)[0].to_s
-          elsif key == 'data_type_id' && a.data_type_id.present?
-            row << DataType.find(a.attributes.values_at(key)[0]).display_name
-          elsif key == 'it_security_incident_status_id'
-            row << ItSecurityIncidentStatus.find(a.attributes.values_at(key)[0]).name
-          elsif ['people_involved', 'equipment_involved', 'remediation_steps', 'notes'].include?(key)
-            rich_text_content = ItSecurityIncident.find(record_id).send(key)
-            text_content = rich_text_content&.to_plain_text || ''
-            row << text_content
-          elsif key == 'tdx_tickets' && ItSecurityIncident.find(record_id).tdx_tickets.present?
-            tickets = ""
-            ItSecurityIncident.find(record_id).tdx_tickets.each do |ticket|
-              tickets += ticket.ticket_link + " ; "
-            end
-            row << tickets
-          else
-            row << a.attributes.values_at(key)[0]
-          end
-        end
-        csv << row
-      end
+      csv << csv_headers
+      csv_records.each { |record| csv << build_row(record) }
     end
   end
 
-  def display_name
-    "#{self.title} - #{self.id}"
+  private
+
+  def self.csv_fields
+    %w[
+      id incomplete title date people_involved equipment_involved remediation_steps
+      estimated_financial_cost notes it_security_incident_status_id data_type_id
+      tdx_tickets
+    ]
+  end
+
+  def self.csv_headers
+    %w[
+      link incomplete title date people_involved equipment_involved remediation_steps
+      estimated_financial_cost notes it_security_incident_status data_type
+      tdx_tickets
+    ].map(&:titleize).map(&:upcase)
+  end
+
+  def self.csv_records
+    includes(:data_type, :it_security_incident_status, :tdx_tickets,
+            :people_involved, :equipment_involved, :remediation_steps, :notes)
+  end
+
+  def self.build_row(record)
+    csv_fields.each_with_object([]) do |field, row|
+      row << format_field(record, field)
+    end
+  end
+
+  def self.format_field(record, field)
+    case field
+    when 'id'
+      generate_url(record)
+    when 'data_type_id'
+      record.data_type&.display_name
+    when 'it_security_incident_status_id'
+      record.it_security_incident_status&.name
+    when 'people_involved', 'equipment_involved', 'remediation_steps', 'notes'
+      record.send(field)&.to_plain_text || ''
+    when 'tdx_tickets'
+      record.tdx_tickets.map(&:ticket_link).join(' ; ')
+    else
+      record.attributes[field]
+    end
+  end
+
+  def self.generate_url(record)
+    Rails.application.routes.url_helpers.it_security_incident_url(
+      record,
+      host: Rails.application.config.action_mailer.default_url_options[:host]
+    )
   end
 
 end

--- a/app/models/it_security_incident.rb
+++ b/app/models/it_security_incident.rb
@@ -123,8 +123,8 @@ class ItSecurityIncident < ApplicationRecord
           elsif key == 'it_security_incident_status_id'
             row << ItSecurityIncidentStatus.find(a.attributes.values_at(key)[0]).name
           elsif ['people_involved', 'equipment_involved', 'remediation_steps', 'notes'].include?(key)
-            html_content = ItSecurityIncident.find(record_id).send(key).body
-            text_content = Nokogiri::HTML(html_content).text.strip
+            rich_text_content = ItSecurityIncident.find(record_id).send(key)
+            text_content = rich_text_content&.to_plain_text || ''
             row << text_content
           elsif key == 'tdx_tickets' && ItSecurityIncident.find(record_id).tdx_tickets.present?
             tickets = ""

--- a/app/models/legacy_os_record.rb
+++ b/app/models/legacy_os_record.rb
@@ -149,8 +149,8 @@ class LegacyOsRecord < ApplicationRecord
             row << Device.find(a.attributes.values_at(key)[0]).display_hostname
             row << Device.find(a.attributes.values_at(key)[0]).display_serial
           elsif ['remediation', 'justification', 'notes'].include?(key)
-            html_content = LegacyOsRecord.find(record_id).send(key).body
-            text_content = Nokogiri::HTML(html_content).text.strip
+            rich_text_content = LegacyOsRecord.find(record_id).send(key)
+            text_content = rich_text_content&.to_plain_text || ''
             row << text_content
           elsif key == 'tdx_tickets' && LegacyOsRecord.find(record_id).tdx_tickets.present?
             tickets = ""

--- a/app/models/sensitive_data_system.rb
+++ b/app/models/sensitive_data_system.rb
@@ -124,53 +124,80 @@ class SensitiveDataSystem < ApplicationRecord
     not_completed
   end
 
+  def display_name
+    "#{self.name} - #{self.id}"
+  end
+
   def self.to_csv
-    fields = %w{id incomplete name owner_username owner_full_name department_id phone additional_dept_contact
-                additional_dept_contact_phone support_poc expected_duration_of_data_retention agreements_related_to_data_types
-                review_date review_contact notes storage_location_id data_type_id device_id tdx_tickets}
-    header = %w{link incomplete name owner_username owner_full_name department phone additional_dept_contact
-                additional_dept_contact_phone support_poc expected_duration_of_data_retention agreements_related_to_data_types
-                review_date review_contact notes storage_location data_type device:_hostname device:_serial tdx_tickets}
-    header.map! { |e| e.titleize.upcase }
-    key_id = 'id'
     CSV.generate(headers: true) do |csv|
-      csv << header
-      all.each do |a|
-        row = []
-        record_id = a.attributes.values_at(key_id)[0]
-        fields.each do |key|
-          if key == 'id'
-            row << "http://localhost:3000/sensitive_data_systems/" + a.attributes.values_at(key)[0].to_s
-          elsif key == 'data_type_id' && a.data_type_id.present?
-            row << DataType.find(a.attributes.values_at(key)[0]).display_name
-          elsif key == 'storage_location_id' && a.data_type_id.present?
-            row << StorageLocation.find(a.attributes.values_at(key)[0]).display_name
-          elsif key == 'department_id' && a.department_id.present?
-            row << Department.find(a.attributes.values_at(key)[0]).name
-          elsif key == 'device_id' && a.device_id.present?
-            row << Device.find(a.attributes.values_at(key)[0]).display_hostname
-            row << Device.find(a.attributes.values_at(key)[0]).display_serial
-          elsif key == 'notes'
-            rich_text_content = SensitiveDataSystem.find(record_id).notes
-            text_content = rich_text_content&.to_plain_text || ''
-            row << text_content
-          elsif key == 'tdx_tickets' && SensitiveDataSystem.find(record_id).tdx_tickets.present?
-            tickets = ""
-            SensitiveDataSystem.find(record_id).tdx_tickets.each do |ticket|
-              tickets += ticket.ticket_link + " ; "
-            end
-            row << tickets
-          else
-            row << a.attributes.values_at(key)[0]
-          end
-        end
-        csv << row
-      end
+      csv << csv_headers
+      csv_records.each { |record| csv << build_row(record) }
     end
   end
 
-  def display_name
-    "#{self.name} - #{self.id}"
+  private
+
+  def self.csv_fields
+    %w[
+      id incomplete name owner_username owner_full_name department_id phone
+      additional_dept_contact additional_dept_contact_phone support_poc
+      expected_duration_of_data_retention agreements_related_to_data_types
+      review_date review_contact notes storage_location_id data_type_id
+      device_id tdx_tickets
+    ]
+  end
+
+  def self.csv_headers
+    %w[
+      link incomplete name owner_username owner_full_name department phone
+      additional_dept_contact additional_dept_contact_phone support_poc
+      expected_duration_of_data_retention agreements_related_to_data_types
+      review_date review_contact notes storage_location data_type
+      device:_hostname device:_serial tdx_tickets
+    ].map(&:titleize).map(&:upcase)
+  end
+
+  def self.csv_records
+    includes(:data_type, :storage_location, :department, :device, :tdx_tickets, :notes)
+  end
+
+  def self.build_row(record)
+    csv_fields.each_with_object([]) do |field, row|
+      row << format_field(record, field)
+    end
+  end
+
+  def self.format_field(record, field)
+    case field
+    when 'id'
+      generate_url(record)
+    when 'data_type_id'
+      record.data_type&.display_name
+    when 'storage_location_id'
+      record.storage_location&.display_name
+    when 'department_id'
+      record.department&.name
+    when 'device_id'
+      format_device(record.device)
+    when 'notes'
+      record.notes&.to_plain_text || ''
+    when 'tdx_tickets'
+      record.tdx_tickets.map(&:ticket_link).join(' ; ')
+    else
+      record.attributes[field]
+    end
+  end
+
+  def self.generate_url(record)
+    Rails.application.routes.url_helpers.sensitive_data_system_url(
+      record,
+      host: Rails.application.config.action_mailer.default_url_options[:host]
+    )
+  end
+
+  def self.format_device(device)
+    return unless device
+    [device.display_hostname, device.display_serial]
   end
 
 end

--- a/app/models/sensitive_data_system.rb
+++ b/app/models/sensitive_data_system.rb
@@ -151,8 +151,8 @@ class SensitiveDataSystem < ApplicationRecord
             row << Device.find(a.attributes.values_at(key)[0]).display_hostname
             row << Device.find(a.attributes.values_at(key)[0]).display_serial
           elsif key == 'notes'
-            html_content = SensitiveDataSystem.find(record_id).notes.body
-            text_content = Nokogiri::HTML(html_content).text
+            rich_text_content = SensitiveDataSystem.find(record_id).notes
+            text_content = rich_text_content&.to_plain_text || ''
             row << text_content
           elsif key == 'tdx_tickets' && SensitiveDataSystem.find(record_id).tdx_tickets.present?
             tickets = ""


### PR DESCRIPTION
- Updated CSV export methods in multiple models to use `to_plain_text` for extracting text content from rich text fields
- Replaced Nokogiri HTML parsing with a more concise and robust approach
- Added null-safe text extraction to prevent errors when rich text content is empty

These changes improve the reliability and readability of CSV export functionality across different models.

This is to address the [RAIC-123 Ticket](https://umlsait.atlassian.net/browse/RAIC-123) from Bob Pelcher